### PR TITLE
triton_network: Add data source for triton_networks

### DIFF
--- a/triton/data_source_network.go
+++ b/triton/data_source_network.go
@@ -3,7 +3,6 @@ package triton
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/joyent/triton-go/network"
@@ -33,22 +32,24 @@ func dataSourceNetworkRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-
 	if len(networks) == 0 {
 		return fmt.Errorf("Your query returned no results. Please change " +
 			"your search criteria and try again.")
 	}
 
-	var netName string
+	var networkName string
 	if name, hasName := d.GetOk("name"); hasName {
-		netName = name.(string)
+		networkName = name.(string)
 	}
 
 	var network *network.Network
 	for _, found := range networks {
-		if strings.Contains(found.Name, netName) {
+		if found.Name == networkName {
 			network = found
 		}
+	}
+	if network == nil {
+		return fmt.Errorf("No Networks found by name %q", networkName)
 	}
 
 	d.SetId(network.Id)

--- a/triton/data_source_network.go
+++ b/triton/data_source_network.go
@@ -1,0 +1,56 @@
+package triton
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/triton-go/network"
+)
+
+func dataSourceNetwork() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetworkRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func dataSourceNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+	net, err := client.Network()
+	if err != nil {
+		return err
+	}
+
+	networks, err := net.List(context.Background(), &network.ListInput{})
+	if err != nil {
+		return err
+	}
+
+	if len(networks) == 0 {
+		return fmt.Errorf("Your query returned no results. Please change " +
+			"your search criteria and try again.")
+	}
+
+	var netName string
+	if name, hasName := d.GetOk("name"); hasName {
+		netName = name.(string)
+	}
+
+	var network *network.Network
+	for _, found := range networks {
+		if strings.Contains(found.Name, netName) {
+			network = found
+		}
+	}
+
+	d.SetId(network.Id)
+	return nil
+}

--- a/triton/data_source_network_test.go
+++ b/triton/data_source_network_test.go
@@ -3,6 +3,7 @@ package triton
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -25,13 +26,25 @@ func TestAccTritonNetwork_basic(t *testing.T) {
 	})
 }
 
+func TestAccTritonNetwork_notfound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTritonNetwork_notfound,
+				ExpectError: regexp.MustCompile(`No Networks found by name \"SDC-Public\"`),
+			},
+		},
+	})
+}
+
 func testAccCheckTritonNetworkDataSourceID(name, networkName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("Can't find Network data source: %s", name)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("Network data source ID not set")
 		}
@@ -46,6 +59,7 @@ func testAccCheckTritonNetworkDataSourceID(name, networkName string) resource.Te
 		if err != nil {
 			return err
 		}
+
 		var network *network.Network
 		for _, found := range networks {
 			if found.Id == rs.Primary.ID {
@@ -61,6 +75,11 @@ func testAccCheckTritonNetworkDataSourceID(name, networkName string) resource.Te
 }
 
 var testAccTritonNetwork_basic = `
+data "triton_network" "base" {
+	name = "Joyent-SDC-Public"
+}
+`
+var testAccTritonNetwork_notfound = `
 data "triton_network" "base" {
 	name = "SDC-Public"
 }

--- a/triton/data_source_network_test.go
+++ b/triton/data_source_network_test.go
@@ -1,0 +1,67 @@
+package triton
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/joyent/triton-go/network"
+)
+
+func TestAccTritonNetwork_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTritonNetwork_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTritonNetworkDataSourceID("data.triton_network.base", "Joyent-SDC-Public"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTritonNetworkDataSourceID(name, networkName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Can't find Network data source: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Network data source ID not set")
+		}
+
+		conn := testAccProvider.Meta().(*Client)
+		net, err := conn.Network()
+		if err != nil {
+			return err
+		}
+
+		networks, err := net.List(context.Background(), &network.ListInput{})
+		if err != nil {
+			return err
+		}
+		var network *network.Network
+		for _, found := range networks {
+			if found.Id == rs.Primary.ID {
+				network = found
+			}
+		}
+		if network.Name != networkName {
+			return fmt.Errorf("Bad ID for data source %q: expected %q, got %q",
+				name, network.Id, rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
+var testAccTritonNetwork_basic = `
+data "triton_network" "base" {
+	name = "SDC-Public"
+}
+`

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -52,7 +52,8 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"triton_image": dataSourceImage(),
+			"triton_image":   dataSourceImage(),
+			"triton_network": dataSourceNetwork(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/triton_network.html.markdown
+++ b/website/docs/d/triton_network.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "triton"
+page_title: "Triton: triton_network"
+sidebar_current: "docs-triton-datasource-network"
+description: |-
+    The `triton_network` data source queries the Triton Network API for network IDs.
+---
+
+# triton\_network
+
+The `triton_network` data source queries the Triton Network API for a network ID
+based on it's name.
+
+## Example Usages
+
+Find the ID of the Joyent-SDC-Private network.
+
+```hcl
+data "triton_network" "private" {
+    name = "Joyent-SDC-Private"
+}
+
+output "private_network_id" {
+    value = "${data.triton_network.private.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (string)
+    The name of the network
+

--- a/website/triton.erb
+++ b/website/triton.erb
@@ -17,6 +17,9 @@
                         <li<%= sidebar_current("docs-triton-datasource-image") %>>
                             <a href="/docs/providers/triton/d/triton_image.html">triton_image</a>
                         </li>
+                        <li<%= sidebar_current("docs-triton-datasource-network") %>>
+                            <a href="/docs/providers/triton/d/triton_network.html">triton_network</a>
+                        </li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
This adds a new data source for pulling up network UUIDs by their name/label. Here's two examples of looking up `Joyent-SDC-Public` and `Joyent-SDC-Private`. Any caps sensitive string part of the network name will match. The first match is used.

```hcl
data "triton_network" "private" {
  name = "SDC-Private"
}

data "triton_network" "public" {
  name = "SDC-Public"
}

resource "triton_machine" "tf-base" {
  name = "tf-base-${count.index}"
  package = "g4-highcpu-512M"
  image = "${data.triton_image.base.id}"

  nic {
    network = "${data.triton_network.public.id}"
  }

  tags {
    version = "1.0.0"
    role = "test"
  }
}
```

/cc @jen20 @sean- 