### PR TITLE
triton_machine: Metadata stanza for defining custom user k/v pairs

### DIFF
--- a/triton/resource_machine.go
+++ b/triton/resource_machine.go
@@ -193,21 +193,25 @@ func resourceMachine() *schema.Resource {
 				Description: "User script to run on boot (every boot on SmartMachines)",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 			},
 			"cloud_config": {
 				Description: "copied to machine on boot",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 			},
 			"user_data": {
 				Description: "Data copied to machine on boot",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 			},
 			"administrator_pw": {
 				Description: "Administrator's initial password (Windows only)",
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 			},
 
 			// deprecated fields

--- a/triton/resource_machine_test.go
+++ b/triton/resource_machine_test.go
@@ -258,6 +258,8 @@ func TestAccTritonMachine_metadata(t *testing.T) {
 	add_metadata := fmt.Sprintf(testAccTritonMachine_metadata_1, machineName)
 	add_metadata_2 := fmt.Sprintf(testAccTritonMachine_metadata_2, machineName)
 	add_metadata_3 := fmt.Sprintf(testAccTritonMachine_metadata_3, machineName)
+	add_metadata_4 := fmt.Sprintf(testAccTritonMachine_metadata_4, machineName)
+	add_metadata_5 := fmt.Sprintf(testAccTritonMachine_metadata_5, machineName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -275,7 +277,8 @@ func TestAccTritonMachine_metadata(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckTritonMachineExists("triton_machine.test"),
 					resource.TestCheckResourceAttr(
-						"triton_machine.test", "user_data", "hello"),
+						"triton_machine.test",
+						"user_data", "hello"),
 				),
 			},
 			{
@@ -284,7 +287,7 @@ func TestAccTritonMachine_metadata(t *testing.T) {
 					testCheckTritonMachineExists("triton_machine.test"),
 					resource.TestCheckResourceAttr(
 						"triton_machine.test",
-						"tags.triton.cns.services", "test-cns-service"),
+						"tags.test", "hello!"),
 				),
 			},
 			{
@@ -293,7 +296,25 @@ func TestAccTritonMachine_metadata(t *testing.T) {
 					testCheckTritonMachineExists("triton_machine.test"),
 					resource.TestCheckResourceAttr(
 						"triton_machine.test",
-						"tags.triton.cns.services", "test-cns-service"),
+						"tags.test", "hello!"),
+				),
+			},
+			{
+				Config: add_metadata_4,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonMachineExists("triton_machine.test"),
+					resource.TestCheckResourceAttr(
+						"triton_machine.test",
+						"metadata.custom_meta", "hello-again"),
+				),
+			},
+			{
+				Config: add_metadata_5,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonMachineExists("triton_machine.test"),
+					resource.TestCheckResourceAttr(
+						"triton_machine.test",
+						"metadata.custom_meta", "hello-two"),
 				),
 			},
 		},
@@ -339,7 +360,7 @@ resource "triton_machine" "test" {
 
   user_data = "hello"
 
-  tags = {
+  tags {
 	test = "hello!"
 	}
 }
@@ -348,7 +369,6 @@ var testAccTritonMachine_metadata_2 = `
 variable "tags" {
   default = {
 	test = "hello!"
-	triton.cns.services = "test-cns-service"
   }
 }
 resource "triton_machine" "test" {
@@ -369,9 +389,42 @@ resource "triton_machine" "test" {
 
   user_data = "hello"
 
-  tags = {
+  tags {
 	test = "hello!"
-	triton.cns.services = "test-cns-service"
+  }
+}
+`
+var testAccTritonMachine_metadata_4 = `
+resource "triton_machine" "test" {
+  name = "%s"
+  package = "g4-highcpu-128M"
+  image = "fb5fe970-e6e4-11e6-9820-4b51be190db9"
+
+  user_data = "hello"
+
+  tags {
+	test = "hello!"
+  }
+
+  metadata {
+	custom_meta = "hello-again"
+  }
+}
+`
+var testAccTritonMachine_metadata_5 = `
+resource "triton_machine" "test" {
+  name = "%s"
+  package = "g4-highcpu-128M"
+  image = "fb5fe970-e6e4-11e6-9820-4b51be190db9"
+
+  user_data = "hello"
+
+  tags {
+	test = "hello!"
+  }
+
+  metadata {
+	custom_meta = "hello-two"
   }
 }
 `

--- a/website/docs/r/triton_machine.html.markdown
+++ b/website/docs/r/triton_machine.html.markdown
@@ -20,8 +20,12 @@ resource "triton_machine" "test-smartos" {
   package = "g3-standard-0.25-smartos"
   image   = "842e6fa6-6e9b-11e5-8402-1b490459e334"
 
-  tags = {
+  tags {
     hello = "world"
+  }
+
+  metadata {
+    hello = "again"
   }
 }
 ```
@@ -52,6 +56,9 @@ The following arguments are supported:
 
 * `tags` - (map)
     A mapping of tags to apply to the machine.
+
+* `metadata` - (map, optional)
+    A mapping of metadata to apply to the machine.
 
 * `package` - (string, Required)
     The name of the package to use for provisioning.


### PR DESCRIPTION
Ref #11 #5

This implements the new metadata stanza while also cleaning up how other metadata derived features are handled. There's also better support for metadata state changes using Triton's DeleteMetadata API that was recently included in `triton-go`.

Here's an example of user defined metadata within `triton_machine`.

```hcl
resource "triton_machine" "tf-base" {
  name = "tf-base-${count.index}"
  package = "g4-highcpu-512M"
  image = "${data.triton_image.base.id}"

  tags {
    version = "1.0.0"
    role = "test"
  }

  metadata {
    seed_token = "f693276a3b89dc35dc5e9adbcf80b2ff"
  }
}
```

Metadata can be added/updated externally to Terraform and refreshed into the state file after. It also can apply to a running instance without any reboot.

/cc @jen20 @sean- 