### PR TITLE
data/image: Add support for `most_recent` to image data_source

### DIFF
--- a/triton/data_source_image.go
+++ b/triton/data_source_image.go
@@ -3,6 +3,7 @@ package triton
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/joyent/triton-go/compute"
@@ -53,8 +54,19 @@ func dataSourceImage() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"most_recent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 		},
 	}
+}
+
+func mostRecentImages(images []*compute.Image) *compute.Image {
+	return sortImages(images)[0]
 }
 
 func dataSourceImageRead(d *schema.ResourceData, meta interface{}) error {
@@ -92,16 +104,25 @@ func dataSourceImageRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	var image *compute.Image
 	if len(images) == 0 {
 		return fmt.Errorf("Your query returned no results. Please change " +
 			"your search criteria and try again.")
 	}
 
 	if len(images) > 1 {
-		return fmt.Errorf("Your query returned more than one result. " +
-			"Please try a more specific search criteria.")
+		recent := d.Get("most_recent").(bool)
+		log.Printf("[DEBUG] triton_image - multiple results found and `most_recent` is set to: %t", recent)
+		if recent {
+			image = mostRecentImages(images)
+		} else {
+			return fmt.Errorf("Your query returned more than one result. " +
+				"Please try a more specific search criteria.")
+		}
+	} else {
+		image = images[0]
 	}
 
-	d.SetId(images[0].ID)
+	d.SetId(image.ID)
 	return nil
 }

--- a/triton/data_source_image_test.go
+++ b/triton/data_source_image_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+const base64LTS = "1f32508c-e6e9-11e6-bc05-8fea9e979940"
+
 func TestAccTritonImage_basic(t *testing.T) {
-	const base64LTS = "1f32508c-e6e9-11e6-bc05-8fea9e979940"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -17,6 +18,22 @@ func TestAccTritonImage_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTritonImage_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTritonImageDataSourceID("data.triton_image.base", base64LTS),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTritonImage_mostRecent(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTritonImage_mostRecent,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTritonImageDataSourceID("data.triton_image.base", base64LTS),
 				),
@@ -48,5 +65,12 @@ var testAccTritonImage_basic = `
 data "triton_image" "base" {
 	name = "base-64-lts"
 	version = "16.4.1"
+}
+`
+
+var testAccTritonImage_mostRecent = `
+data "triton_image" "base" {
+	name = "base-64-lts"
+	most_recent = true
 }
 `

--- a/triton/image_sort.go
+++ b/triton/image_sort.go
@@ -1,0 +1,29 @@
+package triton
+
+import (
+	"sort"
+
+	"github.com/joyent/triton-go/compute"
+)
+
+type imageSort []*compute.Image
+
+func sortImages(images []*compute.Image) []*compute.Image {
+	sortedImages := images
+	sort.Sort(sort.Reverse(imageSort(sortedImages)))
+	return sortedImages
+}
+
+func (a imageSort) Len() int {
+	return len(a)
+}
+
+func (a imageSort) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a imageSort) Less(i, j int) bool {
+	itime := a[i].PublishedAt
+	jtime := a[j].PublishedAt
+	return itime.Unix() < jtime.Unix()
+}

--- a/website/docs/d/triton_image.html.markdown
+++ b/website/docs/d/triton_image.html.markdown
@@ -53,3 +53,5 @@ The following arguments are supported:
 * `type` - (string)
     The image type. Must be one of: `zone-dataset`, `lx-dataset`, `zvol`, `docker` or
     `other`.
+
+* `most_recent` - (bool) If more than one result is returned, use the most recent Image.


### PR DESCRIPTION
Fixes: #18

Will sort the images returned from the API and return the latest when
requested:

```
% make testacc TEST=./triton TESTARGS='-run=TestAccTritonImage_'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./triton -v -run=TestAccTritonImage_ -timeout 120m
=== RUN   TestAccTritonImage_basic
--- PASS: TestAccTritonImage_basic (11.28s)
=== RUN   TestAccTritonImage_mostRecent
--- PASS: TestAccTritonImage_mostRecent (13.19s)
PASS
ok  	github.com/terraform-providers/terraform-provider-triton/triton	24.490s
```