### PR TITLE
triton_machine: Introduce new Locality stanza

### DIFF
--- a/triton/resource_machine_test.go
+++ b/triton/resource_machine_test.go
@@ -363,6 +363,29 @@ func TestAccTritonMachine_cns(t *testing.T) {
 	})
 }
 
+func TestAccTritonMachine_locality(t *testing.T) {
+	machineName := fmt.Sprintf("acctest-%d", acctest.RandInt())
+	locality_fixture_1 := fmt.Sprintf(testAccTritonMachine_locality_1, machineName, machineName, machineName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTritonMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: locality_fixture_1,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonMachineExists("triton_machine.test3"),
+					resource.TestCheckResourceAttrSet(
+						"triton_machine.test3", "locality.0.far_from.0"),
+					resource.TestCheckResourceAttrSet(
+						"triton_machine.test3", "locality.0.close_to.0"),
+				),
+			},
+		},
+	})
+}
+
 var testAccTritonMachine_basic = `
 resource "triton_machine" "test" {
   name = "%s"
@@ -504,6 +527,32 @@ resource "triton_machine" "test" {
   }
 }
 `
+
+var testAccTritonMachine_locality_1 = `
+resource "triton_machine" "test1" {
+  name = "%s-1"
+  package = "g4-highcpu-128M"
+  image = "fb5fe970-e6e4-11e6-9820-4b51be190db9"
+}
+
+resource "triton_machine" "test2" {
+  name = "%s-2"
+  package = "g4-highcpu-128M"
+  image = "fb5fe970-e6e4-11e6-9820-4b51be190db9"
+}
+
+resource "triton_machine" "test3" {
+  name = "%s-3"
+  package = "g4-highcpu-128M"
+  image = "fb5fe970-e6e4-11e6-9820-4b51be190db9"
+
+  locality {
+	far_from = ["${triton_machine.test1.id}"]
+	close_to = ["${triton_machine.test2.id}"]
+  }
+}
+`
+
 var testAccTritonMachine_singleNIC = func(name string, vlanNumber int, subnetNumber int) string {
 	return fmt.Sprintf(`resource "triton_vlan" "test" {
 	  vlan_id = %d

--- a/website/docs/r/triton_machine.html.markdown
+++ b/website/docs/r/triton_machine.html.markdown
@@ -31,6 +31,7 @@ resource "triton_machine" "test-smartos" {
   metadata {
     hello = "again"
   }
+
 }
 ```
 
@@ -76,6 +77,9 @@ The following arguments are supported:
 * `nic` - (list of NIC blocks, Optional)
     NICs associated with the machine. The fields allowed in a `NIC` block are defined below.
 
+* `locality` - (map of Locality hints, Optional)
+    A mapping of [Locality](https://apidocs.joyent.com/cloudapi/#CreateMachine) attributes to apply to the machine that assist in datacenter placement. NOTE: Locality hints are only used at the time of machine creation and not referenced after.
+
 * `firewall_enabled` - (boolean)  Default: `false`
     Whether the cloud firewall should be enabled for this machine.
 
@@ -117,3 +121,8 @@ The following attributes are used by `cns`:
 
 * `services` - (list of strings) - The list of services that group this instance with others under a shared domain name.
 * `disable` - (boolean) - The ability to temporarily disable CNS services domains (optional).
+
+The following attributes are used as `locality` hints:
+
+* `close_to` - (list of strings) - List of container UUIDs that a new instance should be placed alongside, on the same host.
+* `far_from` - (list of strings) - List of container UUIDs that a new instance should not be placed onto the same host.


### PR DESCRIPTION
Ref: #19 

~*WIP*: This is a **work-in-progress PR** but I wanted to submit it in case anyone wanted to test. I cranked it out before the weekend and didn't do much testing/refactoring once I got the initial behavior in.~

This introduces the locality stanza. You'll only be able to use this on create as the data is never returned to Terraform after provisioning. However, so far, it's been working for me with the following configuration...

```hcl
provider "triton" {}

data "triton_image" "base" {
  name    = "base-64"
  os      = "smartos"
  type    = "zone-dataset"
  state   = "active"
  version = "17.2.0"
}

data "triton_network" "public" {
  name = "Joyent-SDC-Public"
}

resource "triton_machine" "base0" {
  name = "bench-0"
  package = "g4-highcpu-512M"
  image = "${data.triton_image.base.id}"

  nic {
    network = "${data.triton_network.public.id}"
  }

  tags {
    version = "1.0.0"
  }

}

resource "triton_machine" "base1" {
  name = "bench-1"
  package = "g4-highcpu-512M"
  image = "${data.triton_image.base.id}"

  nic {
    network = "${data.triton_network.public.id}"
  }

  tags {
    version = "1.0.0"
  }

  locality {
    strict = true
    far_from = ["${triton_machine.base0.id}"]
  }

}
```

/cc @sean- 