### PR TITLE
Introduce retryOnError for retrying calls to Triton

### DIFF
--- a/triton/resource_fabric.go
+++ b/triton/resource_fabric.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/triton-go/compute"
 	"github.com/joyent/triton-go/network"
 )
 
@@ -188,8 +189,13 @@ func resourceFabricDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return n.Fabrics().Delete(context.Background(), &network.DeleteFabricInput{
-		FabricVLANID: d.Get("vlan_id").(int),
-		NetworkID:    d.Id(),
+	_, err2 := retryOnError(compute.IsInvalidArgument, func() (interface{}, error) {
+		err := n.Fabrics().Delete(context.Background(), &network.DeleteFabricInput{
+			FabricVLANID: d.Get("vlan_id").(int),
+			NetworkID:    d.Id(),
+		})
+		return nil, err
 	})
+
+	return err2
 }

--- a/triton/resource_machine.go
+++ b/triton/resource_machine.go
@@ -742,9 +742,12 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 				if !exists {
 
 					log.Printf("[DEBUG] Adding NIC with Network %s", new.(string))
-					_, err := c.Instances().AddNIC(context.Background(), &compute.AddNICInput{
-						InstanceID: d.Id(),
-						Network:    new.(string),
+					_, err := retryOnError(compute.IsResourceFound, func() (interface{}, error) {
+						_, err := c.Instances().AddNIC(context.Background(), &compute.AddNICInput{
+							InstanceID: d.Id(),
+							Network:    new.(string),
+						})
+						return nil, err
 					})
 					if err != nil {
 						return err

--- a/triton/resource_machine.go
+++ b/triton/resource_machine.go
@@ -718,9 +718,12 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 					}
 
 					log.Printf("[DEBUG] Removing NIC with MacId %s", macId)
-					err := c.Instances().RemoveNIC(context.Background(), &compute.RemoveNICInput{
-						InstanceID: d.Id(),
-						MAC:        macId,
+					_, err := retryOnError(compute.IsResourceFound, func() (interface{}, error) {
+						err := c.Instances().RemoveNIC(context.Background(), &compute.RemoveNICInput{
+							InstanceID: d.Id(),
+							MAC:        macId,
+						})
+						return nil, err
 					})
 					if err != nil {
 						return err

--- a/triton/tritonerr.go
+++ b/triton/tritonerr.go
@@ -1,0 +1,28 @@
+package triton
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// retryOnError uses resource.Retry from Terraform core to retry a function when
+// specific Triton errors are thrown. The first argument is a function from
+// `triton-go` which checks the error returned by the function of the second
+// argument. Error functions can be found in `triton-go`.
+func retryOnError(isRetry func(err error) bool, f func() (interface{}, error)) (interface{}, error) {
+	var resp interface{}
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var err error
+		resp, err = f()
+		if err != nil {
+			if isRetry(err) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	return resp, err
+}


### PR DESCRIPTION
My hope was to address some of the timing issues around deletions. The goal is to retry given a known error and continue to attempt provisioning until that error is gone. This has helped some of the known issues I've experienced in practice but has not fixed the issue under acceptance testing.

Sharing this for open feedback w/ @jen20 @stack72 