### PR TITLE
Bump triton-go to latest patch

### DIFF
--- a/vendor/github.com/joyent/triton-go/compute/instances.go
+++ b/vendor/github.com/joyent/triton-go/compute/instances.go
@@ -100,7 +100,7 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 	if response != nil {
 		defer response.Body.Close()
 	}
-	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
+	if response == nil || response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
 		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -525,44 +525,44 @@
 		{
 			"checksumSHA1": "0rEZ1HKhlPYgpoXzeG7mzbqwoBM=",
 			"path": "github.com/joyent/triton-go",
-			"revision": "b37e4764ee209a29835d89c7b9974b880da61a27",
-			"revisionTime": "2017-09-11T20:25:24Z"
+			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
+			"revisionTime": "2017-09-20T20:27:53Z"
 		},
 		{
 			"checksumSHA1": "9pLI8JNmkYVLaDkGjn4LNIZnXrA=",
 			"path": "github.com/joyent/triton-go/account",
-			"revision": "b37e4764ee209a29835d89c7b9974b880da61a27",
-			"revisionTime": "2017-09-11T20:25:24Z"
+			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
+			"revisionTime": "2017-09-20T20:27:53Z"
 		},
 		{
 			"checksumSHA1": "JKf97EAAAZFQ6Wf8qN9X7TWqNBY=",
 			"path": "github.com/joyent/triton-go/authentication",
-			"revision": "b37e4764ee209a29835d89c7b9974b880da61a27",
-			"revisionTime": "2017-09-11T20:25:24Z"
+			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
+			"revisionTime": "2017-09-20T20:27:53Z"
 		},
 		{
 			"checksumSHA1": "dlO1or0cyVMAmZzyLcBuoy+M0xU=",
 			"path": "github.com/joyent/triton-go/client",
-			"revision": "b37e4764ee209a29835d89c7b9974b880da61a27",
-			"revisionTime": "2017-09-11T20:25:24Z"
+			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
+			"revisionTime": "2017-09-20T20:27:53Z"
 		},
 		{
-			"checksumSHA1": "FNoAftbygz9IcOh9WW+W5+y2d5o=",
+			"checksumSHA1": "zM+Ad7PShBPlJ//srSqfZEelgPg=",
 			"path": "github.com/joyent/triton-go/compute",
-			"revision": "b37e4764ee209a29835d89c7b9974b880da61a27",
-			"revisionTime": "2017-09-11T20:25:24Z"
+			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
+			"revisionTime": "2017-09-20T20:27:53Z"
 		},
 		{
 			"checksumSHA1": "J5EB7wTJKTUKrhP2NZ4jcbZkctw=",
 			"path": "github.com/joyent/triton-go/identity",
-			"revision": "b37e4764ee209a29835d89c7b9974b880da61a27",
-			"revisionTime": "2017-09-11T20:25:24Z"
+			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
+			"revisionTime": "2017-09-20T20:27:53Z"
 		},
 		{
 			"checksumSHA1": "gyLtPyKlcumRSkrAH+SsDQo1GnY=",
 			"path": "github.com/joyent/triton-go/network",
-			"revision": "b37e4764ee209a29835d89c7b9974b880da61a27",
-			"revisionTime": "2017-09-11T20:25:24Z"
+			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
+			"revisionTime": "2017-09-20T20:27:53Z"
 		},
 		{
 			"checksumSHA1": "guxbLo8KHHBeM0rzou4OTzzpDNs=",


### PR DESCRIPTION
This includes the latest NPE patch within [joyent/triton-go](http://github.com/joyent/triton-go).