### PR TITLE
triton_machine: Introduce new affinity rules feature

### DIFF
--- a/triton/client.go
+++ b/triton/client.go
@@ -1,6 +1,8 @@
 package triton
 
 import (
+	"sync"
+
 	"github.com/hashicorp/errwrap"
 
 	triton "github.com/joyent/triton-go"
@@ -15,6 +17,7 @@ import (
 type Client struct {
 	config                *triton.ClientConfig
 	insecureSkipTLSVerify bool
+	affinityLock          *sync.RWMutex
 }
 
 func (c Client) Account() (*account.AccountClient, error) {

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/errwrap"
@@ -117,6 +118,7 @@ func (c Config) newClient() (*Client, error) {
 	return &Client{
 		config:                config,
 		insecureSkipTLSVerify: c.InsecureSkipTLSVerify,
+		affinityLock:          &sync.RWMutex{},
 	}, nil
 }
 

--- a/vendor/github.com/joyent/triton-go/compute/instances.go
+++ b/vendor/github.com/joyent/triton-go/compute/instances.go
@@ -208,6 +208,7 @@ type CreateInstanceInput struct {
 	Package         string
 	Image           string
 	Networks        []string
+	Affinity        []string
 	LocalityStrict  bool
 	LocalityNear    []string
 	LocalityFar     []string
@@ -217,7 +218,7 @@ type CreateInstanceInput struct {
 	CNS             InstanceCNS
 }
 
-func (input *CreateInstanceInput) toAPI() map[string]interface{} {
+func (input *CreateInstanceInput) toAPI() (map[string]interface{}, error) {
 	const numExtraParams = 8
 	result := make(map[string]interface{}, numExtraParams+len(input.Metadata)+len(input.Tags))
 
@@ -239,16 +240,28 @@ func (input *CreateInstanceInput) toAPI() map[string]interface{} {
 		result["networks"] = input.Networks
 	}
 
-	locality := struct {
-		Strict bool     `json:"strict"`
-		Near   []string `json:"near,omitempty"`
-		Far    []string `json:"far,omitempty"`
-	}{
-		Strict: input.LocalityStrict,
-		Near:   input.LocalityNear,
-		Far:    input.LocalityFar,
+	// validate that affinity and locality are not included together
+	hasAffinity := len(input.Affinity) > 0
+	hasLocality := len(input.LocalityNear) > 0 || len(input.LocalityFar) > 0
+	if hasAffinity && hasLocality {
+		return nil, fmt.Errorf("Cannot include both Affinity and Locality")
 	}
-	result["locality"] = locality
+
+	// affinity takes precendence over locality regardless
+	if len(input.Affinity) > 0 {
+		result["affinity"] = input.Affinity
+	} else {
+		locality := struct {
+			Strict bool     `json:"strict"`
+			Near   []string `json:"near,omitempty"`
+			Far    []string `json:"far,omitempty"`
+		}{
+			Strict: input.LocalityStrict,
+			Near:   input.LocalityNear,
+			Far:    input.LocalityFar,
+		}
+		result["locality"] = locality
+	}
 
 	for key, value := range input.Tags {
 		result[fmt.Sprintf("tag.%s", key)] = value
@@ -266,15 +279,20 @@ func (input *CreateInstanceInput) toAPI() map[string]interface{} {
 		result[fmt.Sprintf("metadata.%s", key)] = value
 	}
 
-	return result
+	return result, nil
 }
 
 func (c *InstancesClient) Create(ctx context.Context, input *CreateInstanceInput) (*Instance, error) {
 	path := fmt.Sprintf("/%s/machines", c.client.AccountName)
+	body, err := input.toAPI()
+	if err != nil {
+		return nil, errwrap.Wrapf("Error preparing Create request: {{err}}", err)
+	}
+
 	reqInputs := client.RequestInput{
 		Method: http.MethodPost,
 		Path:   path,
-		Body:   input.toAPI(),
+		Body:   body,
 	}
 	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
 	if respReader != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -525,44 +525,44 @@
 		{
 			"checksumSHA1": "0rEZ1HKhlPYgpoXzeG7mzbqwoBM=",
 			"path": "github.com/joyent/triton-go",
-			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
-			"revisionTime": "2017-09-20T20:27:53Z"
+			"revision": "2a2bd67ae4e1c5b10f801f15ad131125d6fb1eaf",
+			"revisionTime": "2017-09-27T19:15:41Z"
 		},
 		{
 			"checksumSHA1": "9pLI8JNmkYVLaDkGjn4LNIZnXrA=",
 			"path": "github.com/joyent/triton-go/account",
-			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
-			"revisionTime": "2017-09-20T20:27:53Z"
+			"revision": "2a2bd67ae4e1c5b10f801f15ad131125d6fb1eaf",
+			"revisionTime": "2017-09-27T19:15:41Z"
 		},
 		{
 			"checksumSHA1": "JKf97EAAAZFQ6Wf8qN9X7TWqNBY=",
 			"path": "github.com/joyent/triton-go/authentication",
-			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
-			"revisionTime": "2017-09-20T20:27:53Z"
+			"revision": "2a2bd67ae4e1c5b10f801f15ad131125d6fb1eaf",
+			"revisionTime": "2017-09-27T19:15:41Z"
 		},
 		{
 			"checksumSHA1": "dlO1or0cyVMAmZzyLcBuoy+M0xU=",
 			"path": "github.com/joyent/triton-go/client",
-			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
-			"revisionTime": "2017-09-20T20:27:53Z"
+			"revision": "2a2bd67ae4e1c5b10f801f15ad131125d6fb1eaf",
+			"revisionTime": "2017-09-27T19:15:41Z"
 		},
 		{
-			"checksumSHA1": "zM+Ad7PShBPlJ//srSqfZEelgPg=",
+			"checksumSHA1": "suEcocJmx2naO5he9KnXVvWuDI0=",
 			"path": "github.com/joyent/triton-go/compute",
-			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
-			"revisionTime": "2017-09-20T20:27:53Z"
+			"revision": "2a2bd67ae4e1c5b10f801f15ad131125d6fb1eaf",
+			"revisionTime": "2017-09-27T19:15:41Z"
 		},
 		{
 			"checksumSHA1": "J5EB7wTJKTUKrhP2NZ4jcbZkctw=",
 			"path": "github.com/joyent/triton-go/identity",
-			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
-			"revisionTime": "2017-09-20T20:27:53Z"
+			"revision": "2a2bd67ae4e1c5b10f801f15ad131125d6fb1eaf",
+			"revisionTime": "2017-09-27T19:15:41Z"
 		},
 		{
 			"checksumSHA1": "gyLtPyKlcumRSkrAH+SsDQo1GnY=",
 			"path": "github.com/joyent/triton-go/network",
-			"revision": "fecc66f11af7523c02d57c68c3f2a84a2ecd626f",
-			"revisionTime": "2017-09-20T20:27:53Z"
+			"revision": "2a2bd67ae4e1c5b10f801f15ad131125d6fb1eaf",
+			"revisionTime": "2017-09-27T19:15:41Z"
 		},
 		{
 			"checksumSHA1": "guxbLo8KHHBeM0rzou4OTzzpDNs=",

--- a/website/docs/r/triton_machine.html.markdown
+++ b/website/docs/r/triton_machine.html.markdown
@@ -25,6 +25,7 @@ resource "triton_machine" "test-smartos" {
 
   tags {
     hello = "world"
+    role = "database"
   }
 
   cns {
@@ -74,6 +75,32 @@ resource "triton_machine" "test-ubuntu" {
 } ## resource
 ```
 
+### Run two SmartOS machine's with placement rules.
+
+```hcl
+resource "triton_machine" "test-db" {
+  name    = "test-db"
+  package = "g4-highcpu-8G"
+  image   = "842e6fa6-6e9b-11e5-8402-1b490459e334"
+
+  affinity = ["role!=~web"]
+
+  tags {
+    role = "database"
+  }
+}
+
+resource "triton_machine" "test-web" {
+  name    = "test-web"
+  package = "g4-highcpu-8G"
+  image   = "842e6fa6-6e9b-11e5-8402-1b490459e334"
+
+  tags {
+    role = "web"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -99,8 +126,11 @@ The following arguments are supported:
 * `networks` - (list, optional)
     The list of networks to associate with the machine. The network ID will be in hex form, e.g `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
 
+* `affinity` - (list of Affinity rules, Optional)
+    A list of valid [Affinity Rules](https://apidocs.joyent.com/cloudapi/#affinity-rules) to apply to the machine which assist in data center placement. Using this attribute will force resource creation to be serial. NOTE: Affinity rules are best guess and assist in placing instances across a data center. They're used at creation and not referenced after.
+
 * `locality` - (map of Locality hints, Optional)
-    A mapping of [Locality](https://apidocs.joyent.com/cloudapi/#CreateMachine) attributes to apply to the machine that assist in datacenter placement. NOTE: Locality hints are only used at the time of machine creation and not referenced after.
+    A mapping of [Locality](https://apidocs.joyent.com/cloudapi/#CreateMachine) attributes to apply to the machine that assist in data center placement. NOTE: Locality hints are only used at the time of machine creation and not referenced after.
 
 * `firewall_enabled` - (boolean)  Default: `false`
     Whether the cloud firewall should be enabled for this machine.


### PR DESCRIPTION
Ref: #32 ([comment](https://github.com/terraform-providers/terraform-provider-triton/issues/32#issuecomment-329029459)) as well as internal ticket PUBAPI-1428.

Triton team is deprecating `locality` in favor of the `affinity` rules feature ported from Docker API into CloudAPI's CreateMachine endpoint. This is still incoming but we're prepping for the release by integrating with the provider (coming to a CloudAPI near you).

We've introduced `affinity` argument to `triton_machine` like so...

```hcl
resource "triton_machine" "db" {
    count = 2

    name = "${format("db-%02d", count.index + 1)}"
    package = "sample-128M"
    image = "${data.triton_image.base.id}"

    affinity = ["role!=database"]

    tags {
        role = "database"
    }

}
```

The syntax used for rule definition are [publicly documented here](https://apidocs.joyent.com/cloudapi/#affinity-rules).

In order to achieve the desired behavior throughout a DC we've serialized resource creation when affinity rules are present (ht @sean-). If affinity is defined on a set of `triton_machine` resources than each resource will be created one after the other. If a resource has a `count > 1` you'll see each resource group created in a serial fashion as well.

Here's a configuration that demonstrates some of the interplay between resource definitions and various options for affinity rules.

<details>

```hcl
provider "triton" {}

data "triton_image" "base" {
    name = "base-64-lts"
    most_recent = true
}

resource "triton_machine" "db" {
    count = 2

    name = "${format("db-%02d", count.index + 1)}"
    package = "sample-128M"
    image = "${data.triton_image.base.id}"
    networks = ["${data.triton_network.public.id}"]

    affinity = ["role!=database"]

    tags {
        role = "database"
    }

}

resource "triton_machine" "web" {
    depends_on = ["triton_machine.db"]

    count = 3

    name = "${format("web-%02d", count.index + 1)}"
    package = "sample-128M"
    image = "${data.triton_image.base.id}"
    networks = ["${data.triton_network.public.id}"]

    affinity = ["instance==~db*", "role!=~web"]

    tags {
        role = "web"
    }
}

resource "triton_machine" "sidecar" {
    count = 3

    name = "${format("sidecar-%02d", count.index + 1)}"
    package = "sample-128M"
    image = "${data.triton_image.base.id}"
    networks = ["${data.triton_network.public.id}"]

    tags {
        role = "sidecar"
    }
}
```

</details>

In the example above we want the following placement...
- We want `db` instances to never be placed next to other `db` ("hard" affinity, `!=`).
- If possible, we want `web` placed next to `db`  ("soft" affinity, `==~`) but never on a CN alongside another `web` instance ("soft" `!=~`).
- `web` has a `depends_on` to ensure it is explicitly dependent upon `db` being created first.
- We have a `sidecar` process that can provision anywhere (no affinity).

Given this setup and the serial nature of provisioning with `affinity`, both `sidecar` and `db` resources will be created first, followed by `web` after. The following is a list of compute nodes that demonstrate the finalized placement (ordered by creation and CN).

```
sidecar-03  0fe605b7-f781-48e8-9056-15f037910d2d
sidecar-02  0fe605b7-f781-48e8-9056-15f037910d2d
db-01       0fe605b7-f781-48e8-9056-15f037910d2d
web-02      0fe605b7-f781-48e8-9056-15f037910d2d

db-02       3ffe48b6-ebd7-4c08-b355-ea2afbe85a37
web-03      3ffe48b6-ebd7-4c08-b355-ea2afbe85a37

sidecar-01  b928db39-b60b-44a7-89c6-c30baf3adaac
web-01      b928db39-b60b-44a7-89c6-c30baf3adaac
```

ATM I'm still fine tuning documentation, linking to the rule syntax, and acceptance tests but wanted to get this out early.