### PR TITLE
Add sweepers for Triton Machines and Firewall Rules

### DIFF
--- a/triton/sweeper_test.go
+++ b/triton/sweeper_test.go
@@ -1,0 +1,47 @@
+package triton
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func sharedConfigForRegion(region string) (interface{}, error) {
+	if os.Getenv("TRITON_ACCOUNT") == "" {
+		return nil, fmt.Errorf("empty TRITON_ACCOUNT")
+	}
+
+	if os.Getenv("TRITON_KEY_ID") == "" {
+		return nil, fmt.Errorf("empty TRITON_KEY_ID")
+	}
+
+	regionUrl := fmt.Sprintf("https://%s.api.joyentcloud.com", region)
+
+	config := Config{
+		Account: os.Getenv("TRITON_ACCOUNT"),
+		URL:     regionUrl,
+		KeyID:   os.Getenv("TRITON_KEY_ID"),
+		InsecureSkipTLSVerify: false,
+	}
+
+	if os.Getenv("TRITON_KEY_MATERIAL") != "" {
+		config.KeyMaterial = os.Getenv("TRITON_KEY_MATERIAL")
+	}
+
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+
+	client, err := config.newClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}


### PR DESCRIPTION
Fixes: #46

This requires TRITON_ACCOUNT and TRITON_KEY_ID to be set. You must pass it a list of regions to run acess. It can take a comma separated list

Then it can be run as follows:

```
go test ./triton -v -sweep=us-sw-1,us-east-1
```

This gives us the output as follows:

```
2017/10/05 14:12:40 [DEBUG] Running Sweepers for region (us-sw-1):
2017/10/05 14:12:41 [DEBUG] Found 0 rules to sweep
2017/10/05 14:12:43 [DEBUG] Found 1 instances to sweep
2017/10/05 14:12:43 Destroying instance acctest-1533927144703045735
2017/10/05 14:12:44 Sweeper Tests ran:
    - triton_firewall_rule
    - triton_machine
ok      github.com/terraform-providers/terraform-provider-triton/triton    4.231s
```