### PR TITLE
website: fix the description of id attribute of triton_machine

### DIFF
--- a/website/docs/r/triton_machine.html.markdown
+++ b/website/docs/r/triton_machine.html.markdown
@@ -154,7 +154,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - (string) - The identifier representing the firewall rule in Triton.
+* `id` - (string) - The identifier representing the machine in Triton.
 * `type` - (string) - The type of the machine (`smartmachine` or `virtualmachine`).
 * `state` - (string) - The current state of the machine.
 * `dataset` - (string) - The dataset URN with which the machine was provisioned.


### PR DESCRIPTION
Fix the description of `id` attribute in triton_machine resource.