### PR TITLE
new_resource: triton_snapshot

### DIFF
--- a/triton/provider.go
+++ b/triton/provider.go
@@ -68,6 +68,7 @@ func Provider() terraform.ResourceProvider {
 			"triton_key":           resourceKey(),
 			"triton_vlan":          resourceVLAN(),
 			"triton_fabric":        resourceFabric(),
+			"triton_snapshot":      resourceSnapshot(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/triton/resource_snapshot.go
+++ b/triton/resource_snapshot.go
@@ -1,0 +1,116 @@
+package triton
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/triton-go/compute"
+)
+
+const (
+	snapshotCreateTimeout = 30 * time.Minute
+)
+
+func resourceSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSnapshotCreate,
+		Read:   resourceSnapshotRead,
+		Delete: resourceSnapshotDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"machine_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+	c, err := client.Compute()
+	if err != nil {
+		return err
+	}
+
+	createInput := &compute.CreateSnapshotInput{
+		MachineID: d.Get("machine_id").(string),
+		Name:      d.Get("name").(string),
+	}
+
+	snapshot, err := c.Snapshots().Create(context.Background(), createInput)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(snapshot.Name)
+
+	stateConf := &resource.StateChangeConf{
+		Target: []string{"created"},
+		Refresh: func() (interface{}, string, error) {
+			snapshot, err := c.Snapshots().Get(context.Background(), &compute.GetSnapshotInput{
+				MachineID: d.Get("machine_id").(string),
+				Name:      d.Id(),
+			})
+			if err != nil {
+				return nil, "", err
+			}
+			return snapshot, snapshot.State, nil
+		},
+		Timeout:    snapshotCreateTimeout,
+		MinTimeout: 3 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return err
+	}
+
+	return resourceSnapshotRead(d, meta)
+}
+
+func resourceSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+	c, err := client.Compute()
+	if err != nil {
+		return err
+	}
+
+	snapshot, err := c.Snapshots().Get(context.Background(), &compute.GetSnapshotInput{
+		MachineID: d.Get("machine_id").(string),
+		Name:      d.Id(),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.Set("state", snapshot.State)
+
+	return nil
+}
+
+func resourceSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+	c, err := client.Compute()
+	if err != nil {
+		return err
+	}
+
+	return c.Snapshots().Delete(context.Background(), &compute.DeleteSnapshotInput{
+		Name:      d.Id(),
+		MachineID: d.Get("machine_id").(string),
+	})
+}

--- a/triton/resource_snapshot_test.go
+++ b/triton/resource_snapshot_test.go
@@ -1,0 +1,112 @@
+package triton
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/joyent/triton-go/compute"
+)
+
+func TestAccTritonSnapshot_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckTritonSnapshotDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTritonSnapshotConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckTritonSnapshotExists("triton_snapshot.test"),
+					func(*terraform.State) error {
+						time.Sleep(30 * time.Second)
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func testCheckTritonSnapshotExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+		conn := testAccProvider.Meta().(*Client)
+		c, err := conn.Compute()
+		if err != nil {
+			return err
+		}
+
+		snapshot, err := c.Snapshots().Get(context.Background(), &compute.GetSnapshotInput{
+			Name:      rs.Primary.ID,
+			MachineID: rs.Primary.Attributes["machine_id"],
+		})
+		if err != nil {
+			return fmt.Errorf("Bad: Check Snapshot Exists: %s", err)
+		}
+
+		if snapshot == nil {
+			return fmt.Errorf("Bad: Snapshot %q does not exist", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testCheckTritonSnapshotDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*Client)
+	c, err := conn.Compute()
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "triton_snapshot" {
+			continue
+		}
+
+		resp, err := c.Snapshots().Get(context.Background(), &compute.GetSnapshotInput{
+			Name:      rs.Primary.ID,
+			MachineID: rs.Primary.Attributes["machine_id"],
+		})
+		if err != nil {
+			if compute.IsResourceNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		if resp != nil && resp.State != "deleted" {
+			return fmt.Errorf("Bad: Snapshot %q still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccTritonSnapshotConfig(rInt int) string {
+	return fmt.Sprintf(`
+data "triton_image" "ubuntu1604" {
+  name = "ubuntu-16.04"
+  version = "20170403"
+}
+
+resource "triton_machine" "test" {
+  image = "${data.triton_image.ubuntu1604.id}"
+  package = "g4-highcpu-128M"
+}
+
+resource "triton_snapshot" "test" {
+  name = "acctest-snap-%d"
+  machine_id = "${triton_machine.test.id}"
+}`, rInt)
+}

--- a/website/docs/r/triton_snapshot.html.markdown
+++ b/website/docs/r/triton_snapshot.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "triton"
+page_title: "Triton: triton_snapshot"
+sidebar_current: "docs-triton-resource-snapshot"
+description: |-
+    The `triton_snapshot` resource represents a snapshot of a Triton machine.
+---
+
+# triton\_snapshot
+
+The `triton_snapshot` resource represents a snapshot of a Triton machine.
+
+## Example Usages
+
+```hcl
+data "triton_image" "ubuntu1604" {
+  name = "ubuntu-16.04"
+  version = "20170403"
+}
+
+resource "triton_machine" "test" {
+  image = "${data.triton_image.ubuntu1604.id}"
+  package = "g4-highcpu-128M"
+}
+
+resource "triton_snapshot" "test" {
+  name = "my-snapshot"
+  machine_id = "${triton_machine.test.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (string)
+    The name for the snapshot.
+
+* `machine_id` - (string, Required)
+    The ID of the machine of which to take a snapshot.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `id` - (string) - The identifier representing the snapshot in Triton.
+* `state` - (string) - The current state of the snapshot.

--- a/website/triton.erb
+++ b/website/triton.erb
@@ -42,6 +42,9 @@
                         <li<%= sidebar_current("docs-triton-resource-machine") %>>
                             <a href="/docs/providers/triton/r/triton_machine.html">triton_machine</a>
                         </li>
+                        <li<%= sidebar_current("docs-triton-resource-snapshot") %>>
+                            <a href="/docs/providers/triton/r/triton_snapshot.html">triton_snapshot</a>
+                        </li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Fixes: #60

```
% acctests triton TestAccTritonSnapshot_basic
=== RUN   TestAccTritonSnapshot_basic
--- PASS: TestAccTritonSnapshot_basic (125.53s)
PASS
ok  	github.com/terraform-providers/terraform-provider-triton/triton	125.543s
```

Adds the `triton_snapshot` resource

@cheapRoc / @jen20 / @sean- 