### PR TITLE
datasource/triton_account: Adds a Triton Account DataSource

### DIFF
--- a/triton/data_source_account.go
+++ b/triton/data_source_account.go
@@ -1,0 +1,39 @@
+package triton
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/triton-go/account"
+)
+
+func dataSourceAccount() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAccountRead,
+		Schema: map[string]*schema.Schema{
+			"cns_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAccountRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+	c, err := client.Account()
+	if err != nil {
+		return err
+	}
+
+	acc, err := c.Get(context.Background(), &account.GetInput{})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(acc.ID)
+
+	d.Set("cns_enabled", acc.TritonCNSEnabled)
+
+	return nil
+}

--- a/triton/data_source_account_test.go
+++ b/triton/data_source_account_test.go
@@ -1,0 +1,28 @@
+package triton
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccTritonAccount(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTritonAccount_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.triton_account.main", "id"),
+					resource.TestCheckResourceAttrSet("data.triton_account.main", "cns_enabled"),
+				),
+			},
+		},
+	})
+}
+
+var testAccTritonAccount_basic = `
+data "triton_account" "main" {}
+`

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -58,6 +58,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"triton_account": dataSourceAccount(),
 			"triton_image":   dataSourceImage(),
 			"triton_network": dataSourceNetwork(),
 		},

--- a/website/docs/d/triton_account.html.markdown
+++ b/website/docs/d/triton_account.html.markdown
@@ -1,0 +1,31 @@
+---
+layout: "triton"
+page_title: "Triton: triton_account"
+sidebar_current: "docs-triton-datasource-account"
+description: |-
+    The `triton_account` data source queries the Triton Account API for account information.
+---
+
+# triton_account
+
+The `triton_account` data source queries the Triton Account API for account information.
+
+## Example Usages
+
+```hcl
+data "triton_account" "main" {}
+
+output "account_id" {
+    value = "${data.triton_account.main.id}"
+}
+```
+
+## Argument Reference
+
+The data source uses the name of the account currently configured to interact with the Triton API.
+
+## Attribute Reference
+
+The following attributes are supported:
+
+* `cns_enabled` - (bool) Whether CNS is enabled for the account.

--- a/website/triton.erb
+++ b/website/triton.erb
@@ -14,6 +14,9 @@
                     <a href="#">Data Sources</a>
 
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-triton-datasource-account") %>>
+                            <a href="/docs/providers/triton/d/triton_account.html">triton_account</a>
+                        </li>
                         <li<%= sidebar_current("docs-triton-datasource-image") %>>
                             <a href="/docs/providers/triton/d/triton_image.html">triton_image</a>
                         </li>


### PR DESCRIPTION
Fixes: #68

```
=== RUN   TestAccTritonAccount
--- PASS: TestAccTritonAccount (3.76s)
PASS
ok  	github.com/terraform-providers/terraform-provider-triton/triton	3.776s
```