### PR TITLE
datasource/datacenter: Adds a datasource for Triton datacenters

### DIFF
--- a/triton/data_source_datacenter.go
+++ b/triton/data_source_datacenter.go
@@ -1,0 +1,48 @@
+package triton
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/triton-go/compute"
+)
+
+func dataSourceDataCenter() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDataCenterRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDataCenterRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+	c, err := client.Compute()
+	if err != nil {
+		return err
+	}
+
+	dcs, err := c.Datacenters().List(context.Background(), &compute.ListDataCentersInput{})
+	if err != nil {
+		return err
+	}
+
+	for _, dc := range dcs {
+		if dc.URL == client.config.TritonURL {
+			d.SetId(time.Now().UTC().String())
+			d.Set("name", dc.Name)
+			d.Set("endpoint", dc.URL)
+		}
+	}
+
+	return nil
+}

--- a/triton/data_source_datacenter_test.go
+++ b/triton/data_source_datacenter_test.go
@@ -1,0 +1,33 @@
+package triton
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccTritonDataCenter(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTritonDataCenter,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.triton_datacenter.current", "name", "us-sw-1"),
+					resource.TestCheckResourceAttr("data.triton_datacenter.current", "endpoint", "https://us-sw-1.api.joyentcloud.com"),
+				),
+			},
+		},
+	})
+}
+
+var testAccTritonDataCenter = `
+
+provider "triton" {
+  url = "https://us-sw-1.api.joyentcloud.com"
+}
+
+data "triton_datacenter" "current" {}
+`

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -58,9 +58,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"triton_account": dataSourceAccount(),
-			"triton_image":   dataSourceImage(),
-			"triton_network": dataSourceNetwork(),
+			"triton_account":    dataSourceAccount(),
+			"triton_datacenter": dataSourceDataCenter(),
+			"triton_image":      dataSourceImage(),
+			"triton_network":    dataSourceNetwork(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/triton_datacenter.html.markdown
+++ b/website/docs/d/triton_datacenter.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "triton"
+page_title: "Triton: triton_datacenter"
+sidebar_current: "docs-triton-datasource-datacenter"
+description: |-
+    The `triton_datacenter` data source queries the Triton Account API for datacenter information.
+---
+
+# triton_datacenter
+
+The `triton_datacenter` data source queries the Triton Account API for datacenter information.
+
+## Example Usages
+
+```hcl
+data "triton_datacenter" "current" {}
+
+output "endpoint" {
+    value = "${data.triton_datacenter.current.endpoint}"
+}
+```
+
+## Argument Reference
+
+The data source uses the endpoint currently configured to interact with the Triton API.
+
+## Attribute Reference
+
+The following attributes are supported:
+
+* `name` - (string) The name of the datacenter.
+* `endpoint` - (string) The endpoint url of the datacenter

--- a/website/triton.erb
+++ b/website/triton.erb
@@ -17,6 +17,9 @@
                         <li<%= sidebar_current("docs-triton-datasource-account") %>>
                             <a href="/docs/providers/triton/d/triton_account.html">triton_account</a>
                         </li>
+                        <li<%= sidebar_current("docs-triton-datasource-datacenter") %>>
+                            <a href="/docs/providers/triton/d/triton_datacenter.html">triton_datacenter</a>
+                        </li>
                         <li<%= sidebar_current("docs-triton-datasource-image") %>>
                             <a href="/docs/providers/triton/d/triton_image.html">triton_image</a>
                         </li>


### PR DESCRIPTION
Fixes: #69

```
terraform-provider-triton [triton-datacenter-datasource] % acctests triton TestAccTritonDataCenter
=== RUN   TestAccTritonDataCenter
--- PASS: TestAccTritonDataCenter (4.37s)
PASS
ok  	github.com/terraform-providers/terraform-provider-triton/triton	4.391s
```