### PR TITLE
dep/triton-go: Bump triton-go dependency to 0.4.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -141,8 +141,8 @@
 [[projects]]
   name = "github.com/joyent/triton-go"
   packages = [".","account","authentication","client","compute","identity","network"]
-  revision = "3213572af2a6b11b1e7de3b6c1db6bd7c4703b34"
-  version = "0.4.1"
+  revision = "48924aec2e8d78dc32d7965ecfb059031a01edf1"
+  version = "0.4.2"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
@@ -249,6 +249,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8e75eeb9755099367e2ddc906550defe33394e5aaa418dfefa1c914818cf3480"
+  inputs-digest = "75f99711d4ca23378f9e45487d298d5f3bf7e9254cbfdfd9aa04a8d6ce349d99"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -35,7 +35,7 @@
 
 [[constraint]]
   name = "github.com/joyent/triton-go"
-  version = "0.4.1"
+  version = "0.4.2"
 
 [[constraint]]
   branch = "master"

--- a/vendor/github.com/joyent/triton-go/CHANGELOG.md
+++ b/vendor/github.com/joyent/triton-go/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Fixing a panic when the user loses network connectivity when making a GET request to instance [#81]
+
+## 0.4.1 (December 15)
+
 - Clean up the handling of directory sanitization. Use abs paths everywhere [#79]
 
 ## 0.4.0 (December 15)

--- a/vendor/github.com/joyent/triton-go/compute/instances.go
+++ b/vendor/github.com/joyent/triton-go/compute/instances.go
@@ -97,10 +97,13 @@ func (c *InstancesClient) Get(ctx context.Context, input *GetInstanceInput) (*In
 		Path:   path,
 	}
 	response, err := c.client.ExecuteRequestRaw(ctx, reqInputs)
-	if response != nil {
+	if response == nil {
+		return nil, errwrap.Wrapf("Error executing Get request: {{err}}", err)
+	}
+	if response.Body != nil {
 		defer response.Body.Close()
 	}
-	if response == nil || response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
+	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusGone {
 		return nil, &client.TritonError{
 			StatusCode: response.StatusCode,
 			Code:       "ResourceNotFound",

--- a/vendor/github.com/joyent/triton-go/storage/objects.go
+++ b/vendor/github.com/joyent/triton-go/storage/objects.go
@@ -260,7 +260,6 @@ func (s *ObjectsClient) Put(ctx context.Context, input *PutObjectInput) error {
 	absPath := absFileInput(s.client.AccountName, input.ObjectPath)
 
 	if input.ForceInsert {
-		// IsDir() uses a path relative to the account
 		absDirName := _AbsCleanPath(path.Dir(string(absPath)))
 		exists, err := checkDirectoryTreeExists(*s, ctx, absDirName)
 		if err != nil {


### PR DESCRIPTION
Fixes: #64 
Changelog entry should read: 

```
resource/machine: Fixed a panic when network connection is dropped during a terraform refresh [#64]
```