### PR TITLE
datasource/datacenter: Cater for old Joyent Cloud URLS in datasource

### DIFF
--- a/triton/data_source_datacenter.go
+++ b/triton/data_source_datacenter.go
@@ -2,6 +2,7 @@ package triton
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -37,7 +38,7 @@ func dataSourceDataCenterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	for _, dc := range dcs {
-		if dc.URL == client.config.TritonURL {
+		if dc.URL == client.config.TritonURL || strings.Replace(dc.URL, "joyentcloud.com", "joyent.com", -1) == client.config.TritonURL {
 			d.SetId(time.Now().UTC().String())
 			d.Set("name", dc.Name)
 			d.Set("endpoint", dc.URL)

--- a/triton/data_source_datacenter_test.go
+++ b/triton/data_source_datacenter_test.go
@@ -23,10 +23,36 @@ func TestAccTritonDataCenter(t *testing.T) {
 	})
 }
 
+func TestAccTritonDataCenterOldUrl(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTritonDataCenterOldUrl,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.triton_datacenter.current", "name", "us-east-1"),
+					resource.TestCheckResourceAttr("data.triton_datacenter.current", "endpoint", "https://us-east-1.api.joyentcloud.com"),
+				),
+			},
+		},
+	})
+}
+
 var testAccTritonDataCenter = `
 
 provider "triton" {
   url = "https://us-sw-1.api.joyentcloud.com"
+}
+
+data "triton_datacenter" "current" {}
+`
+
+var testAccTritonDataCenterOldUrl = `
+
+provider "triton" {
+  url = "https://us-east-1.api.joyent.com"
 }
 
 data "triton_datacenter" "current" {}


### PR DESCRIPTION
```
terraform-provider-triton [master●] % acctests triton TestAccTritonDataCenter
=== RUN   TestAccTritonDataCenter
--- PASS: TestAccTritonDataCenter (4.68s)
=== RUN   TestAccTritonDataCenterOldUrl
--- PASS: TestAccTritonDataCenterOldUrl (4.66s)
PASS
ok  	github.com/terraform-providers/terraform-provider-triton/triton	9.362s
```