### PR TITLE
sweepers: Sweepers were tied to only work in the JPC

### DIFF
--- a/triton/sweeper_test.go
+++ b/triton/sweeper_test.go
@@ -21,11 +21,9 @@ func sharedConfigForRegion(region string) (interface{}, error) {
 		return nil, fmt.Errorf("empty TRITON_KEY_ID")
 	}
 
-	regionUrl := fmt.Sprintf("https://%s.api.joyentcloud.com", region)
-
 	config := Config{
 		Account: os.Getenv("TRITON_ACCOUNT"),
-		URL:     regionUrl,
+		URL:     os.Getenv("TRITON_URL"),
 		KeyID:   os.Getenv("TRITON_KEY_ID"),
 		InsecureSkipTLSVerify: false,
 	}


### PR DESCRIPTION
We hardcoded the url, we should use the env var. The value we pass to
the sweepers, just means that we can bypass the check to make sure a
region is present

The sweepers will now work in SPC :)