### PR TITLE
Introduce packages data source

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -139,10 +139,10 @@
   revision = "0b12d6b5"
 
 [[projects]]
-  branch = "master"
   name = "github.com/joyent/triton-go"
   packages = [".","account","authentication","client","compute","errors","identity","network"]
-  revision = "545edbe0d564f075ac576f1ad177f4ff39c9adaf"
+  revision = "392ffed0d35d888782b18ea9ef8709f253d2da36"
+  version = "0.9.0"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
@@ -255,6 +255,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dd2c68239c220875299959ed265fd047f1276774ce0e568ebb955514dfef6136"
+  inputs-digest = "def06b141e608751284ffa2f4f6b0b4ff5723315889b0410099ed5d9215c22f1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,7 +34,7 @@
   version = "0.10.7"
 
 [[constraint]]
-  branch = "master"
+  version = "0.9.0"
   name = "github.com/joyent/triton-go"
 
 [[constraint]]

--- a/triton/data_source_package.go
+++ b/triton/data_source_package.go
@@ -1,0 +1,203 @@
+package triton
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/triton-go/compute"
+)
+
+func dataSourceFiltersSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeSet,
+		Required: true,
+		ForceNew: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+
+				"memory": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+
+				"disk": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+
+				"swap": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+
+				"lwps": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+
+				"vcpus": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+
+				"version": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+
+				"group": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func dataSourcePackage() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePackageRead,
+		Schema: map[string]*schema.Schema{
+
+			"filter": dataSourceFiltersSchema(),
+
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"memory": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"disk": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"swap": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"lwps": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"vcpus": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"group": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePackageRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+	c, err := client.Compute()
+	if err != nil {
+		return err
+	}
+
+	filters := map[string]interface{}{}
+	if filterSet, found := d.Get("filter").(*schema.Set); found {
+		filterRaw := filterSet.List()[0]
+		if filterRaw == nil {
+			return fmt.Errorf("Please set filters on your package data source.")
+		}
+		filters = filterRaw.(map[string]interface{})
+	}
+
+	input := &compute.ListPackagesInput{}
+
+	if memory := int64(filters["memory"].(int)); memory > 0 {
+		input.Memory = memory
+	}
+	if disk := int64(filters["disk"].(int)); disk > 0 {
+		input.Disk = disk
+	}
+	if swap := int64(filters["swap"].(int)); swap > 0 {
+		input.Swap = swap
+	}
+	if lwps := int64(filters["lwps"].(int)); lwps > 0 {
+		input.LWPs = lwps
+	}
+	if vcpus := int64(filters["vcpus"].(int)); vcpus > 0 {
+		input.VCPUs = vcpus
+	}
+	if version := filters["version"].(string); version != "" {
+		input.Version = version
+	}
+	if group := filters["group"].(string); group != "" {
+		input.Group = group
+	}
+
+	packages, err := c.Packages().List(context.Background(), input)
+	if err != nil {
+		return err
+	}
+	if len(packages) == 0 {
+		return fmt.Errorf("Your query returned no results. Please change " +
+			"your filter criteria and try again.")
+	}
+
+	iname, hasName := filters["name"]
+	name := iname.(string)
+
+	var pkg *compute.Package
+	if hasName {
+		for _, p := range packages {
+			if strings.Contains(p.Name, name) {
+				pkg = p
+				break
+			}
+		}
+	}
+
+	if pkg == nil {
+		names := make([]string, 0)
+		for _, pkg := range packages {
+			if hasName {
+				if strings.Contains(pkg.Name, name) {
+					names = append(names, pkg.Name)
+				}
+			} else {
+				names = append(names, pkg.Name)
+			}
+		}
+		return fmt.Errorf(
+			"Your query returned more than one result (%v).\nPlease change "+
+				"your filter criteria and try again.", strings.Join(names, ", "))
+	}
+
+	d.SetId(pkg.ID)
+	d.Set("name", pkg.Name)
+	d.Set("memory", pkg.Memory)
+	d.Set("disk", pkg.Disk)
+	d.Set("swap", pkg.Swap)
+	d.Set("lwps", pkg.LWPs)
+	d.Set("vcpus", pkg.VCPUs)
+	d.Set("version", pkg.Version)
+	d.Set("group", pkg.Group)
+
+	return nil
+}

--- a/triton/data_source_package_test.go
+++ b/triton/data_source_package_test.go
@@ -1,0 +1,54 @@
+package triton
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const (
+	testPackageName = "g4-highcpu-128M"
+)
+
+func TestAccTritonPackage_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTritonPackage_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTritonPackageDataSourceID("data.triton_package.base", testPackageName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTritonPackageDataSourceID(name, packageName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("can't find package data source: %s", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("returned package ID should not be empty")
+		}
+		if rs.Primary.Attributes["name"] != packageName {
+			return fmt.Errorf("returned package Name does not match")
+		}
+
+		return nil
+	}
+}
+
+var testAccTritonPackage_basic = `
+data "triton_package" "base" {
+	filter {
+	   name = "highcpu"
+	   memory = 128
+	}
+}
+`

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -66,6 +66,7 @@ func Provider() terraform.ResourceProvider {
 			"triton_datacenter": dataSourceDataCenter(),
 			"triton_image":      dataSourceImage(),
 			"triton_network":    dataSourceNetwork(),
+			"triton_package":    dataSourcePackage(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/vendor/github.com/joyent/triton-go/CHANGELOG.md
+++ b/vendor/github.com/joyent/triton-go/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.9.0 (January 23)
+
+**Please Note:** This is a precursor release to marking triton-go as 1.0.0. We are going to wait and fix any bugs that occur from this large set of changes that has happened since 0.5.2
+
 - Add support for managing columes in Triton [#100]
 - identity/policies: Add support for managing policies in Triton [#86]
 - addition of triton-go errors package to expose unwraping of internal errors

--- a/vendor/github.com/joyent/triton-go/compute/packages.go
+++ b/vendor/github.com/joyent/triton-go/compute/packages.go
@@ -11,7 +11,9 @@ package compute
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
 	"path"
 
 	"github.com/joyent/triton-go/client"
@@ -49,10 +51,37 @@ type ListPackagesInput struct {
 
 func (c *PackagesClient) List(ctx context.Context, input *ListPackagesInput) ([]*Package, error) {
 	fullPath := path.Join("/", c.client.AccountName, "packages")
+
+	query := &url.Values{}
+	if input.Name != "" {
+		query.Set("name", input.Name)
+	}
+	if input.Memory != 0 {
+		query.Set("memory", fmt.Sprintf("%d", input.Memory))
+	}
+	if input.Disk != 0 {
+		query.Set("disk", fmt.Sprintf("%d", input.Disk))
+	}
+	if input.Swap != 0 {
+		query.Set("swap", fmt.Sprintf("%d", input.Swap))
+	}
+	if input.LWPs != 0 {
+		query.Set("lwps", fmt.Sprintf("%d", input.LWPs))
+	}
+	if input.VCPUs != 0 {
+		query.Set("vcpus", fmt.Sprintf("%d", input.VCPUs))
+	}
+	if input.Version != "" {
+		query.Set("version", input.Version)
+	}
+	if input.Group != "" {
+		query.Set("group", input.Group)
+	}
+
 	reqInputs := client.RequestInput{
 		Method: http.MethodGet,
 		Path:   fullPath,
-		Body:   input,
+		Query:  query,
 	}
 	respReader, err := c.client.ExecuteRequest(ctx, reqInputs)
 	if respReader != nil {


### PR DESCRIPTION
This PR includes a new data source for pulling Package information out of Triton's CloudAPI. Looking for early feedback before I wrap up.

A Package in Triton specifies resources allocated to a machine instance. In order to run a compute instance a consumer must choose a package by various attributes like memory, disk, and swap size.

The HCL looks like this...

```hcl
provider "triton" {
    insecure_skip_tls_verify = true
}

data "triton_package" "highcpu" {
    filter {
        name = "highcpu"
        memory = 8192
    }
}

data "triton_image" "image" {
    name = "base-64-lts"
    most_recent = true
}

resource "triton_machine" "test" {
    name = "${format("test-%02d", count.index + 1)}"
    package = "${data.triton_package.highcpu.name}"
    image = "${data.triton_image.image.id}"
}
```

This currently evaluates to the following execution plan...

```
  + triton_machine.test
      id:                   <computed>
      created:              <computed>
      dataset:              <computed>
      disk:                 <computed>
      domain_names.#:       <computed>
      firewall_enabled:     "false"
      image:                "390639d4-f146-11e7-9280-37ae5c6d53d4"
      ips.#:                <computed>
      memory:               <computed>
      name:                 "test-01"
      nic.#:                <computed>
      package:              "g4-highcpu-8G"
      primaryip:            <computed>
      root_authorized_keys: <computed>
      type:                 <computed>
      updated:              <computed>
```

In order to make this easier to use we provide a way to search for a sub string within a Package's name. Otherwise, any other attributes will be forwarded into CloudAPI's backend filtering mechanism.

EDIT: Side note, the reason for the `filter` block is so we can provide different ways to filter packages besides the static attributes they already have. In the case above we're drawing a distinction between filter name `highcpu` and the actual name `g4-highcpu-8G`.  In the future it would be nice to provide a short name for sizes such as `memory` and `disk`, replacing `8192` with `8G`.