### PR TITLE
resource/machine: Expose compute_node in machine resource

### DIFF
--- a/triton/resource_machine.go
+++ b/triton/resource_machine.go
@@ -277,6 +277,11 @@ func resourceMachine() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 			},
+			"compute_node": {
+				Description: "UUID of the server on which the instance is located",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -475,6 +480,7 @@ func resourceMachineRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("primaryip", machine.PrimaryIP)
 	d.Set("firewall_enabled", machine.FirewallEnabled)
 	d.Set("domain_names", machine.DomainNames)
+	d.Set("compute_node", machine.ComputeNode)
 
 	// create and update NICs
 	var (

--- a/triton/resource_machine_test.go
+++ b/triton/resource_machine_test.go
@@ -70,6 +70,7 @@ func TestAccTritonMachine_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckTritonMachineExists("triton_machine.test"),
+					resource.TestCheckResourceAttrSet("triton_machine.test", "compute_node"),
 					func(*terraform.State) error {
 						time.Sleep(30 * time.Second)
 						return nil

--- a/website/docs/r/triton_machine.html.markdown
+++ b/website/docs/r/triton_machine.html.markdown
@@ -164,6 +164,7 @@ The following attributes are exported:
 * `primaryip` - (string) - The primary (public) IP address for the machine.
 * `created` - (string) - The time at which the machine was created.
 * `updated` - (string) - The time at which the machine was last updated.
+* `compute_node` - (string) - UUID of the server on which the instance is located.
 
 * `nic` - A list of the networks that the machine is attached to. Each network is represented by a `nic`, each of which has the following properties:
 


### PR DESCRIPTION
Fixes: #87

```
terraform-provider-triton [master●] % acctests triton TestAccTritonMachine_basic
=== RUN   TestAccTritonMachine_basic
--- PASS: TestAccTritonMachine_basic (119.13s)
PASS
ok  	github.com/terraform-providers/terraform-provider-triton/triton	119.168s
```