### PR TITLE
Update the triton_datacenter data source.

### DIFF
--- a/triton/data_source_datacenter.go
+++ b/triton/data_source_datacenter.go
@@ -2,13 +2,16 @@ package triton
 
 import (
 	"context"
+	"log"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/joyent/triton-go/compute"
+	"github.com/pkg/errors"
 )
 
+// dataSourceDataCenter returns schema for the Data Center data source.
 func dataSourceDataCenter() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceDataCenterRead,
@@ -25,23 +28,35 @@ func dataSourceDataCenter() *schema.Resource {
 	}
 }
 
+// dataSourceDataCenterRead retrieves a list of all data centers from Triton
+// using the Data Center API. The current Data Center endpoint URL will be
+// the same as the one currently configured in the Triton provider.
 func dataSourceDataCenterRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Client)
+
 	c, err := client.Compute()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error creating Compute client")
 	}
 
+	log.Printf("[DEBUG] triton_datacenter: Reading Data Center details.")
 	dcs, err := c.Datacenters().List(context.Background(), &compute.ListDataCentersInput{})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error retrieving Data Center details")
 	}
 
+	tritonURL := client.config.TritonURL
+
 	for _, dc := range dcs {
-		if dc.URL == client.config.TritonURL || strings.Replace(dc.URL, "joyentcloud.com", "joyent.com", -1) == client.config.TritonURL {
+		// Normalize the endpoint URL in a case of Triton (CloudAPI) (for
+		// example, when using the Triton Public Cloud) returns an old domain
+		// name "joyentcloud.com".
+		if dc.URL == tritonURL || strings.Replace(dc.URL, "joyentcloud.com", "joyent.com", -1) == tritonURL {
+			log.Printf("[DEBUG] triton_datacenter: Found matching Data Center: %+v", dc)
 			d.SetId(time.Now().UTC().String())
 			d.Set("name", dc.Name)
 			d.Set("endpoint", dc.URL)
+			break
 		}
 	}
 

--- a/triton/data_source_datacenter_test.go
+++ b/triton/data_source_datacenter_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestAccTritonDataCenter(t *testing.T) {
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -23,14 +22,13 @@ func TestAccTritonDataCenter(t *testing.T) {
 	})
 }
 
-func TestAccTritonDataCenterOldUrl(t *testing.T) {
-
+func TestAccTritonDataCenterOldURL(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTritonDataCenterOldUrl,
+				Config: testAccTritonDataCenterOldURL,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.triton_datacenter.current", "name", "us-east-1"),
 					resource.TestCheckResourceAttr("data.triton_datacenter.current", "endpoint", "https://us-east-1.api.joyentcloud.com"),
@@ -41,18 +39,16 @@ func TestAccTritonDataCenterOldUrl(t *testing.T) {
 }
 
 var testAccTritonDataCenter = `
-
 provider "triton" {
-  url = "https://us-sw-1.api.joyentcloud.com"
+  url = "https://us-sw-1.api.joyent.com"
 }
 
 data "triton_datacenter" "current" {}
 `
 
-var testAccTritonDataCenterOldUrl = `
-
+var testAccTritonDataCenterOldURL = `
 provider "triton" {
-  url = "https://us-east-1.api.joyent.com"
+  url = "https://us-east-1.api.joyentcloud.com"
 }
 
 data "triton_datacenter" "current" {}

--- a/website/docs/d/triton_datacenter.html.markdown
+++ b/website/docs/d/triton_datacenter.html.markdown
@@ -3,18 +3,25 @@ layout: "triton"
 page_title: "Triton: triton_datacenter"
 sidebar_current: "docs-triton-datasource-datacenter"
 description: |-
-    The `triton_datacenter` data source queries the Triton Account API for datacenter information.
+  The `triton_datacenter` data source queries Triton for Data Center information.
 ---
 
 # triton_datacenter
 
-The `triton_datacenter` data source queries the Triton Account API for datacenter information.
+The `triton_datacenter` data source queries Triton for Data Center information.
+
+~> **NOTE:** This data source uses the endpoint URL of the Data Center currently
+configured in the [Trition provider][1].
 
 ## Example Usages
 
+Find current Data Center endpoint URL:
+
 ```hcl
+# Declare the data source.
 data "triton_datacenter" "current" {}
 
+# Access current endpoint URL using output from the data source.
 output "endpoint" {
   value = "${data.triton_datacenter.current.endpoint}"
 }
@@ -22,11 +29,22 @@ output "endpoint" {
 
 ## Argument Reference
 
-The data source uses the endpoint currently configured to interact with the Triton API.
+There are no arguments available for this data source.
 
 ## Attribute Reference
 
+~> **NOTE:** When using the [Triton Public Cloud](https://www.joyent.com/triton),
+the `endpoint` attribute might include an old, but still fully supported, domain
+name "joyentcloud.com" (e.g. https://us-east-1.api.joyentcloud.com), even when
+the new domain name "joyent.com" has been used to configure the cloud endpoint
+URL in the [Trition provider][1].
+
 The following attributes are supported:
 
-* `name` - (string) The name of the datacenter.
-* `endpoint` - (string) The endpoint url of the datacenter
+* `name` - (string)
+    The name of the Data Center.
+
+* `endpoint` - (string)
+    The endpoint URL of the Data Center.
+
+[1]: /docs/providers/triton/index.html


### PR DESCRIPTION
This commit updates the `triton_datacenter` data source with the following changes:

  - Adds more logging at the debug level
  - Adds more comments to the code
  - Updates error messages
  - Updates documentation
  - Renames method and variable name as per the guideline at
    https://github.com/golang/go/wiki/CodeReviewComments#initialisms
  - Moves old Triton data centre URL to the right variable in the acceptance test

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>