### PR TITLE
Add new `triton_fabric_vlan` data source.

### DIFF
--- a/triton/data_source_fabric_vlan.go
+++ b/triton/data_source_fabric_vlan.go
@@ -1,0 +1,131 @@
+package triton
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/triton-go/network"
+	"github.com/pkg/errors"
+)
+
+// filterVLANFunc is a function that is called to filter a Fabric VLAN from
+// a slice of Fabric VLANs based on a predicate.
+type filterVLANFunc func(*network.FabricVLAN) bool
+
+// dataSourceFabricVLAN returns schema for the Fabric VLAN data source.
+func dataSourceFabricVLAN() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFabricVLANRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"vlan_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateVLANIdentifier,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+// dataSourceFabricVLANRead retrieves details about all the Fabric VLANs
+// which are available in the current Data Center from the Fabrics API,
+// then searches for a matching Fabric VLAN using either name, VLAN ID
+// or description as filter, or a combination of thereof.
+func dataSourceFabricVLANRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	vlanName, vlanNameOk := d.GetOk("name")
+	vlanID, vlanIDOk := d.GetOk("vlan_id")
+	vlanDesc, vlanDescOk := d.GetOk("description")
+
+	if !vlanNameOk && !vlanIDOk && !vlanDescOk {
+		return errors.New("one of `name`, `vlan_id`, or `description` must be assigned")
+	}
+
+	net, err := client.Network()
+	if err != nil {
+		return errors.Wrap(err, "error creating Network client")
+	}
+
+	log.Printf("[DEBUG] triton_fabric_vlan: Reading Fabric VLAN details.")
+	vlans, err := net.Fabrics().ListVLANs(context.Background(), &network.ListVLANsInput{})
+	if err != nil {
+		return errors.Wrap(err, "error retrieving Fabric VLAN details")
+	}
+
+	matches := vlans
+
+	// There can be many Fabric VLANs sharing the same name and description
+	// within the data center (neither name nor description are unique), and
+	// the only way to uniquely identify a single Fabric VLAN would be either
+	// its VLAN ID (which is always a match) and either a very specific name
+	// or description, or a combination of thereof. We allow the end-user to
+	// use multiple attributes as filters together to granularly narrow down
+	// results so that only a single Fabric VLAN would be found. All of the
+	// filters create an implicit AND relationship between one another, and
+	// in a case of the name and description attributes, a simple wildcard
+	// match can be used.
+	if vlanIDOk {
+		matches = filterVLANs(matches, func(v *network.FabricVLAN) bool {
+			return v.ID == vlanID.(int)
+		})
+	}
+	if vlanNameOk {
+		matches = filterVLANs(matches, func(v *network.FabricVLAN) bool {
+			return wildcardMatch(vlanName.(string), v.Name)
+		})
+	}
+	if vlanDescOk {
+		matches = filterVLANs(matches, func(v *network.FabricVLAN) bool {
+			return wildcardMatch(vlanDesc.(string), v.Description)
+		})
+	}
+
+	var vlan *network.FabricVLAN
+	if len(matches) == 0 {
+		return errors.New("unable to find any Fabric VLANs matching the " +
+			"current search criteria, please change your search criteria " +
+			"and try again")
+	}
+
+	if len(matches) > 1 {
+		log.Printf("[DEBUG] triton_fabric_vlan: Found multiple matching Fabric VLANs: %+v", matches)
+		return errors.New("found multiple Fabric VLANs matching the " +
+			"current search criteria, please change your search criteria " +
+			"and try again")
+	}
+
+	vlan = matches[0]
+
+	log.Printf("[DEBUG] triton_fabric_vlan: Found matching Fabric VLAN: %+v", vlan)
+	d.SetId(time.Now().UTC().String())
+
+	d.Set("name", vlan.Name)
+	d.Set("vlan_id", vlan.ID)
+	d.Set("description", vlan.Description)
+
+	return nil
+}
+
+// filterVLANs iterates over a slice of Fabric VLANs, and returns a slice that
+// contains all of the Fabric VLANs the predicate returns a value of true for.
+func filterVLANs(vlans []*network.FabricVLAN, f filterVLANFunc) (results []*network.FabricVLAN) {
+	for _, vlan := range vlans {
+		if f(vlan) {
+			results = append(results, vlan)
+		}
+	}
+	return
+}

--- a/triton/data_source_fabric_vlan_test.go
+++ b/triton/data_source_fabric_vlan_test.go
@@ -1,0 +1,329 @@
+package triton
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccTritonFabricVLAN_MissingArguments(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTritonFabricVLANMissingArguments,
+				ExpectError: regexp.MustCompile("one of `name`, `vlan_id`, or `description` must be assigned"),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricVLAN_BadArguments(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTritonFabricVLANBadArguments,
+				ExpectError: regexp.MustCompile(`.* \\"vlan_id\\" value must be between 0 and 4095`),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricVLAN_Basic(t *testing.T) {
+	vlanID := acctest.RandIntRange(3, 2048)
+	resourcesOnly, config := testAccTritonFabricVLANBasic(vlanID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesOnly,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"name",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"vlan_id",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"description",
+					),
+					resource.TestCheckResourceAttr(
+						"data.triton_fabric_vlan.test",
+						"vlan_id",
+						fmt.Sprintf("%d", vlanID),
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricVLAN_WildCard(t *testing.T) {
+	vlanID := acctest.RandIntRange(3, 2048)
+	resourcesOnly, config := testAccTritonFabricVLANWildCard(vlanID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesOnly,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"name",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"vlan_id",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"description",
+					),
+					resource.TestCheckResourceAttr(
+						"data.triton_fabric_vlan.test",
+						"vlan_id",
+						fmt.Sprintf("%d", vlanID),
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricVLAN_Filters(t *testing.T) {
+	vlanID := acctest.RandIntRange(3, 2048)
+	resourcesOnly, config := testAccTritonFabricVLANFilters(vlanID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesOnly,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"name",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"vlan_id",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_vlan.test",
+						"description",
+					),
+					resource.TestCheckResourceAttr(
+						"data.triton_fabric_vlan.test",
+						"vlan_id",
+						fmt.Sprintf("%d", vlanID),
+					),
+					resource.TestCheckResourceAttr(
+						"data.triton_fabric_vlan.test",
+						"description",
+						fmt.Sprintf("Test Fabric VLAN %d", vlanID),
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricVLAN_NotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTritonFabricVLANNotFound,
+				ExpectError: regexp.MustCompile(`unable to find any Fabric VLANs matching .* try again`),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricVLAN_FiltersNotFound(t *testing.T) {
+	vlanID := acctest.RandIntRange(3, 2048)
+	resourcesOnly, config := testAccTritonFabricVLANFiltersNotFound(vlanID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesOnly,
+			},
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`unable to find any Fabric VLANs matching .* try again`),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricVLAN_MultipleFound(t *testing.T) {
+	vlanID := acctest.RandIntRange(3, 2048)
+	resourcesOnly, config := testAccTritonFabricVLANMultipleFound(vlanID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesOnly,
+			},
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`found multiple Fabric VLANs matching .* try again`),
+			},
+		},
+	})
+}
+
+var testAccTritonFabricVLANMissingArguments = `
+  data "triton_fabric_vlan" "test" {}
+`
+
+var testAccTritonFabricVLANBadArguments = `
+  data "triton_fabric_vlan" "test" {
+    vlan_id = 12345
+  }
+`
+
+var testAccTritonFabricVLANNotFound = `
+  data "triton_fabric_vlan" "test" {
+    name = "Bad-Fabric-VLAN-Name"
+  }
+`
+
+var testAccTritonFabricVLANBasic = func(vlanID int) (string, string) {
+	resources := fmt.Sprintf(`
+  resource "triton_vlan" "test" {
+    name        = "Test-Fabric-VLAN-%d"
+    vlan_id     = %d
+    description = "Test Fabric VLAN %d"
+  }
+`, vlanID, vlanID, vlanID)
+
+	both := fmt.Sprintf(`%s
+  data "triton_fabric_vlan" "test" {
+    name = "Test-Fabric-VLAN-%d"
+  }
+`, resources, vlanID)
+
+	return resources, both
+}
+
+var testAccTritonFabricVLANWildCard = func(vlanID int) (string, string) {
+	resources := fmt.Sprintf(`
+  resource "triton_vlan" "test" {
+    name        = "Test-Fabric-VLAN-%d"
+    vlan_id     = %d
+    description = "Test Fabric VLAN %d"
+  }
+`, vlanID, vlanID, vlanID)
+
+	both := fmt.Sprintf(`%s
+  data "triton_fabric_vlan" "test" {
+    name = "Tes?-*-VLA?-%d"
+  }
+`, resources, vlanID)
+
+	return resources, both
+}
+
+var testAccTritonFabricVLANFilters = func(vlanID int) (string, string) {
+	resources := fmt.Sprintf(`
+  resource "triton_vlan" "test_1" {
+    name        = "Test-Fabric-VLAN-%d"
+    vlan_id     = %d
+    description = "Test Fabric VLAN %d"
+  }
+
+  resource "triton_vlan" "test_2" {
+    name    = "Test-Fabric-VLAN-%d"
+    vlan_id = %d
+  }
+`, vlanID, vlanID, vlanID, vlanID, vlanID+1)
+
+	both := fmt.Sprintf(`%s
+  data "triton_fabric_vlan" "test" {
+    name        = "Tes?-*-VLA?-*"
+    description = "Test * %d"
+  }
+`, resources, vlanID)
+
+	return resources, both
+}
+
+var testAccTritonFabricVLANFiltersNotFound = func(vlanID int) (string, string) {
+	resources := fmt.Sprintf(`
+  resource "triton_vlan" "test_1" {
+    name    = "Test-Fabric-VLAN-%d"
+    vlan_id = %d
+  }
+
+  resource "triton_vlan" "test_2" {
+    name    = "Test-Fabric-VLAN-%d"
+    vlan_id = %d
+  }
+`, vlanID, vlanID, vlanID, vlanID+1)
+
+	both := fmt.Sprintf(`%s
+  data "triton_fabric_vlan" "test" {
+    name    = "Bad-Fabric-VLAN-Name"
+    vlan_id = %d
+  }
+`, resources, vlanID)
+
+	return resources, both
+}
+
+var testAccTritonFabricVLANMultipleFound = func(vlanID int) (string, string) {
+	resources := fmt.Sprintf(`
+  resource "triton_vlan" "test_1" {
+    name    = "Test-Fabric-VLAN-%d"
+    vlan_id = %d
+  }
+
+  resource "triton_vlan" "test_2" {
+    name    = "Test-Fabric-VLAN-%d"
+    vlan_id = %d
+  }
+`, vlanID, vlanID, vlanID, vlanID+1)
+
+	both := fmt.Sprintf(`%s
+  data "triton_fabric_vlan" "test" {
+    name = "Test-Fabric-VLAN-%d"
+  }
+`, resources, vlanID)
+
+	return resources, both
+}

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -62,11 +62,12 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"triton_account":    dataSourceAccount(),
-			"triton_datacenter": dataSourceDataCenter(),
-			"triton_image":      dataSourceImage(),
-			"triton_network":    dataSourceNetwork(),
-			"triton_package":    dataSourcePackage(),
+			"triton_account":     dataSourceAccount(),
+			"triton_datacenter":  dataSourceDataCenter(),
+			"triton_image":       dataSourceImage(),
+			"triton_network":     dataSourceNetwork(),
+			"triton_package":     dataSourcePackage(),
+			"triton_fabric_vlan": dataSourceFabricVLAN(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/triton/utils.go
+++ b/triton/utils.go
@@ -1,0 +1,56 @@
+package triton
+
+// wildcardMatch performs a simple wildcard pattern match against a string
+// value. This implementation uses Russ Cox's linear match algorithm, and
+// supports only two types of common wildcards:
+//
+// * - matches any number of any characters including none; and
+// ? - matches one occurrence of any character.
+//
+// There is no support for either ranges or character classes.
+func wildcardMatch(pattern, s string) bool {
+	p := 0
+	n := 0
+	nextP := 0
+	nextN := 0
+
+	// Would always match.
+	if pattern == "*" {
+		return true
+	}
+
+	for n < len(s) || p < len(pattern) {
+		if p < len(pattern) {
+			c := pattern[p]
+
+			switch c {
+			case '?':
+				if n < len(s) {
+					p++
+					n++
+					continue
+				}
+			case '*':
+				nextP = p
+				nextN = n + 1
+				p++
+				continue
+			default:
+				if n < len(s) && s[n] == c {
+					p++
+					n++
+					continue
+				}
+			}
+		}
+
+		// Restart.
+		if 0 < nextN && nextN <= len(s) {
+			p = nextP
+			n = nextN
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/triton/utils_test.go
+++ b/triton/utils_test.go
@@ -1,0 +1,144 @@
+package triton
+
+import "testing"
+
+func TestWildcardMatch(t *testing.T) {
+	cases := []struct {
+		value    string
+		pattern  string
+		expected bool
+	}{
+		{
+			"",
+			"",
+			true,
+		},
+		{
+			"",
+			"*",
+			true,
+		},
+		{
+			"",
+			"?",
+			false,
+		},
+		{
+			"",
+			"triton",
+			false,
+		},
+		{
+			"triton",
+			"",
+			false,
+		},
+		{
+			"triton",
+			"*",
+			true,
+		},
+		{
+			"triton",
+			"?",
+			false,
+		},
+		{
+			"triton",
+			"*n",
+			true,
+		},
+		{
+			"triton",
+			"?*",
+			true,
+		},
+		{
+			"triton",
+			"t*",
+			true,
+		},
+		{
+			"triton",
+			"t*n",
+			true,
+		},
+		{
+			"triton",
+			"?*n",
+			true,
+		},
+		{
+			"triton",
+			"triton",
+			true,
+		},
+		{
+			"triton",
+			"??????",
+			true,
+		},
+		{
+			"triton",
+			"trito?",
+			true,
+		},
+		{
+			"triton",
+			"?riton",
+			true,
+		},
+		{
+			"triton",
+			"t?it?n",
+			true,
+		},
+		{
+			"triton",
+			"*triton",
+			true,
+		},
+		{
+			"triton",
+			"triton*",
+			true,
+		},
+		{
+			"triton",
+			"?triton",
+			false,
+		},
+		{
+			"triton",
+			"triton?",
+			false,
+		},
+		{
+			"txrxixtxoxnx",
+			"t*r*i*t*o*nx",
+			true,
+		},
+		{
+			"txrxixtxoxnn",
+			"t*r*i*t*o*n*",
+			true,
+		},
+		{
+			"trxrrxritonx",
+			"t*r?t*o*n*x*",
+			true,
+		},
+		{
+			"trxrrxritonn",
+			"t*r?t*o*n*x",
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		actual := wildcardMatch(tc.pattern, tc.value)
+		if actual != tc.expected {
+			t.Errorf("expected %q to match %q, got %t", tc.pattern, tc.value, actual)
+		}
+	}
+}

--- a/triton/validators.go
+++ b/triton/validators.go
@@ -1,0 +1,13 @@
+package triton
+
+import "fmt"
+
+// validateVLANIdentifier validates that the integer value is a valid VLAN ID,
+// which for the Fabric VLAN must be in the range between 0 and 4095 inclusive.
+func validateVLANIdentifier(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(int)
+	if value < 0 || value > 4095 {
+		errors = append(errors, fmt.Errorf("%q value must be between 0 and 4095", k))
+	}
+	return
+}

--- a/triton/validators_test.go
+++ b/triton/validators_test.go
@@ -1,0 +1,44 @@
+package triton
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateVLANIdentifier(t *testing.T) {
+	cases := []struct {
+		value  int
+		errors int
+	}{
+		{
+			value:  -1,
+			errors: 1,
+		},
+		{
+			value:  0,
+			errors: 0,
+		},
+		{
+			value:  4095,
+			errors: 0,
+		},
+		{
+			value:  4096,
+			errors: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errs := validateVLANIdentifier(tc.value, "vlan_id")
+		if len(errs) != tc.errors {
+			t.Errorf("expected %d validation errors for value %d, got %d", tc.errors, tc.value, len(errs))
+		}
+	}
+
+	_, errs := validateVLANIdentifier(12345, "vlan_id")
+
+	e := errs[0]
+	if !strings.Contains(e.Error(), `"vlan_id" value must be between 0 and 4095`) {
+		t.Errorf("expected error to equal test error, got %s", e)
+	}
+}

--- a/website/docs/d/triton_fabric_vlan.html.markdown
+++ b/website/docs/d/triton_fabric_vlan.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "triton"
+page_title: "Triton: triton_fabric_vlan"
+sidebar_current: "docs-triton-datasource-fabric-vlan"
+description: |-
+  The `triton_fabric_vlan` data source queries Triton for Fabric VLAN information
+  (e.g., VLAN ID, etc.) based either on the name, VLAN ID or description of the
+  Fabric VLAN.
+---
+
+# triton_fabric_vlan
+
+The `triton_fabric_vlan` data source queries Triton for [Fabric VLAN][1]
+information (e.g., VLAN ID, etc.) based either on the name, VLAN ID or
+description of the Fabric VLAN.
+
+## Example Usages
+
+Find the VLAN ID using the name of the Fabric VLAN as a search filter:
+
+```hcl
+# Declare the data source.
+data "triton_fabric_vlan" "public" {
+  name = "Public-VLAN-Production"
+}
+
+# Access unique VLAN ID using output from the data source.
+output "public_vlan_id" {
+  value = "${data.triton_fabric_vlan.public.vlan_id}"
+}
+```
+
+Find the VLAN ID using name (with a wildcard match) and description of
+the Fabric VLAN as a search filters:
+
+```hcl
+# Declare the data source, and use a combination of two arguments
+# to form a search filter. Use a wildcard match for the name.
+data "triton_fabric_vlan" "private_database_vlan" {
+  name        = "Private-VLAN-*"
+  description = "A secure VLAN for production database servers"
+}
+
+# Access unique VLAN ID using output from the data source.
+output "private_database_vlan_id" {
+  value = "${data.triton_fabric_vlan.private_database_vlan.vlan_id}"
+}
+```
+## Argument Reference
+
+~> **NOTE:** The arguments of this data source act as filters when searching for
+a matching Fabric VLAN and can be combined together, but at lease one of `name`,
+`vlan_id` or `description` must be assigned.
+
+The following arguments are supported:
+
+* `name` - (string)
+    Optional. The name of the Fabric VLAN.
+
+* `vlan_id` - (integer)
+    Optional. The unique identifier (VLAN ID) of the Fabric VLAN.
+
+* `description` - (string)
+    Optional. The description of the Fabric VLAN.
+
+~> **NOTE:** Both the `name` and `description` arguments support a simple wildcard
+pattern matching using two common wildcards, such as **`*`** (asterisk) and **`?`**.
+There is no support for either ranges or character classes. More details about
+wildcard patterm matching can be found [here][2].
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `name` - (string)
+    The name of the Fabric VLAN, if any.
+
+* `vlan_id` - (integer)
+    The unique identifier (VLAN ID) of the Fabric VLAN.
+
+* `description` - (string)
+    The description of the Fabric VLAN, if any.
+
+[1]: https://docs.joyent.com/public-cloud/network/sdn#vlans
+[2]: https://en.wikipedia.org/wiki/Glob_(programming)

--- a/website/triton.erb
+++ b/website/triton.erb
@@ -26,6 +26,9 @@
                         <li<%= sidebar_current("docs-triton-datasource-network") %>>
                             <a href="/docs/providers/triton/d/triton_network.html">triton_network</a>
                         </li>
+                        <li<%= sidebar_current("docs-triton-datasource-triton-fabric-vlan") %>>
+                            <a href="/docs/providers/triton/d/triton_fabric_vlan.html">triton_fabric_vlan</a>
+                        </li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
This commit adds new data source called `triton_fabric_vlan`, which allows the
end-user to find details about a particular Fabric VLAN based on attributes such
as name, VLAN ID or description. Each of the attribute can be used as a filter
allowing to narrow down results more granularly (each filter creates an
implicit AND relationship with the other).

Additionally, this commit introduces a new `wildcardMatch` function that can be
used to perform simple pattern matches against a string value, and a function
`validateVLANIdentifier` that can be used in the schema where the `ValidateFunc`
is to be expected to verify whether the value for the Fabric VLAN ID is within
the correct range.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>