### PR TITLE
Add new `triton_fabric_network` data source.

### DIFF
--- a/triton/data_source_fabric_network.go
+++ b/triton/data_source_fabric_network.go
@@ -1,0 +1,127 @@
+package triton
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/triton-go/network"
+	"github.com/pkg/errors"
+)
+
+// dataSourceFabricNetwork returns schema for the Fabric Network data source.
+func dataSourceFabricNetwork() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceFabricNetworkRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"public": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"fabric": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"provision_start_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"provision_end_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gateway": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"resolvers": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"routes": {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+			"internet_nat": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"vlan_id": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateVLANIdentifier,
+			},
+		},
+	}
+}
+
+// dataSourceFabricNetworkRead retrieves details about all the Fabric Networks
+// from a specific VLAN in the current Data Center from the Fabrics API, then
+// searches for a matching Fabric Network in the list of available networks
+// using network name as a filter.
+func dataSourceFabricNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client)
+
+	fabricName := d.Get("name").(string)
+	vlanID := d.Get("vlan_id").(int)
+
+	net, err := client.Network()
+	if err != nil {
+		return errors.Wrap(err, "error creating Network client")
+	}
+
+	log.Printf("[DEBUG] triton_fabric_network: Reading Fabric Network details on VLAN %d", vlanID)
+	fabrics, err := net.Fabrics().List(context.Background(), &network.ListFabricsInput{
+		FabricVLANID: vlanID,
+	})
+	if err != nil {
+		return errors.Wrap(err, "error retrieving Fabric Network details")
+	}
+
+	var result *network.Network
+	for _, fabric := range fabrics {
+		if fabric.Fabric && fabric.Name == fabricName {
+			log.Printf("[DEBUG] triton_fabric_network: Found matching Fabric Network: %+v", fabric)
+			result = fabric
+			break
+		}
+	}
+	if result == nil {
+		return fmt.Errorf("unable to find any Fabric Network with name %q "+
+			"on the VLAN %d, please change your search criteria "+
+			"and try again", fabricName, vlanID)
+	}
+
+	d.SetId(result.Id)
+	d.Set("name", result.Name)
+	d.Set("public", result.Public)
+	d.Set("fabric", result.Fabric)
+	d.Set("description", result.Description)
+	d.Set("subnet", result.Subnet)
+	d.Set("provision_start_ip", result.ProvisioningStartIP)
+	d.Set("provision_end_ip", result.ProvisioningEndIP)
+	d.Set("gateway", result.Gateway)
+	d.Set("resolvers", result.Resolvers)
+	d.Set("routes", result.Routes)
+	d.Set("internet_nat", result.InternetNAT)
+	d.Set("vlan_id", vlanID) // The VLAN ID is not part of the `network.Network` type.
+
+	return nil
+}

--- a/triton/data_source_fabric_network_test.go
+++ b/triton/data_source_fabric_network_test.go
@@ -1,0 +1,175 @@
+package triton
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccTritonFabricNetwork_MissingArguments(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTritonFabricNetworkMissingArguments,
+				ExpectError: regexp.MustCompile(`.* \\"name\\": .* \\"vlan_id\\": .* field is not set.*`),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricNetwork_BadArguments(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTritonFabricNetworkBadArguments,
+				ExpectError: regexp.MustCompile(`.* \\"vlan_id\\" value must be between 0 and 4095`),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricNetwork_NotFound(t *testing.T) {
+	vlanID := acctest.RandIntRange(3, 2048)
+	resourcesOnly, config := testAccTritonFabricNetworkNotFound(vlanID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesOnly,
+			},
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`unable to find .* "Bad-Fabric-Network-Name" .* try again`),
+			},
+		},
+	})
+}
+
+func TestAccTritonFabricNetwork_Basic(t *testing.T) {
+	vlanID := acctest.RandIntRange(3, 2048)
+	resourcesOnly, config := testAccTritonFabricNetworkBasic(vlanID)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			{
+				Config: resourcesOnly,
+			},
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_network.test",
+						"name",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_network.test",
+						"subnet",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_network.test",
+						"provision_start_ip",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_network.test",
+						"provision_end_ip",
+					),
+					resource.TestCheckResourceAttrSet(
+						"data.triton_fabric_network.test",
+						"gateway",
+					),
+					resource.TestCheckResourceAttr(
+						"data.triton_fabric_network.test",
+						"resolvers.#",
+						"2",
+					),
+					resource.TestCheckResourceAttr(
+						"data.triton_fabric_network.test",
+						"vlan_id",
+						fmt.Sprintf("%d", vlanID),
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.triton_fabric_network.test",
+						"vlan_id",
+						"triton_vlan.test",
+						"id",
+					),
+				),
+			},
+		},
+	})
+}
+
+var testAccTritonFabricNetworkMissingArguments = `
+  data "triton_fabric_network" "test" {}
+`
+
+var testAccTritonFabricNetworkBadArguments = `
+  data "triton_fabric_network" "test" {
+    name    = "Test-Fabric-Network"
+    vlan_id = 12345
+  }
+`
+
+var testAccTritonFabricNetworkNotFound = func(vlanID int) (string, string) {
+	resources := fmt.Sprintf(`
+  resource "triton_vlan" "test" {
+    name    = "Test-Fabric-VLAN-%d"
+    vlan_id = %d
+  }
+`, vlanID, vlanID)
+
+	both := fmt.Sprintf(`%s
+  data "triton_fabric_network" "test" {
+    name    = "Bad-Fabric-Network-Name"
+    vlan_id = %d
+  }
+`, resources, vlanID)
+
+	return resources, both
+}
+
+var testAccTritonFabricNetworkBasic = func(vlanID int) (string, string) {
+	resources := fmt.Sprintf(`
+  resource "triton_vlan" "test" {
+    name    = "Test-Fabric-VLAN-%d"
+    vlan_id = %d
+  }
+
+  resource "triton_fabric" "test" {
+    name = "Test-Fabric-Network-%d"
+
+    subnet             = "10.0.0.0/24"
+    provision_start_ip = "10.0.0.2"
+    provision_end_ip   = "10.0.0.254"
+    gateway            = "10.0.0.1"
+
+    resolvers = [
+      "8.8.8.8",
+      "8.8.4.4",
+    ]
+
+    vlan_id = "${triton_vlan.test.id}"
+  }
+`, vlanID, vlanID, vlanID)
+
+	both := fmt.Sprintf(`%s
+  data "triton_fabric_network" "test" { 
+    name    = "Test-Fabric-Network-%d"
+    vlan_id = %d
+  }
+`, resources, vlanID, vlanID)
+
+	return resources, both
+}

--- a/triton/provider.go
+++ b/triton/provider.go
@@ -62,12 +62,13 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"triton_account":     dataSourceAccount(),
-			"triton_datacenter":  dataSourceDataCenter(),
-			"triton_image":       dataSourceImage(),
-			"triton_network":     dataSourceNetwork(),
-			"triton_package":     dataSourcePackage(),
-			"triton_fabric_vlan": dataSourceFabricVLAN(),
+			"triton_account":        dataSourceAccount(),
+			"triton_datacenter":     dataSourceDataCenter(),
+			"triton_image":          dataSourceImage(),
+			"triton_network":        dataSourceNetwork(),
+			"triton_package":        dataSourcePackage(),
+			"triton_fabric_vlan":    dataSourceFabricVLAN(),
+			"triton_fabric_network": dataSourceFabricNetwork(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/docs/d/triton_fabric_network.html.markdown
+++ b/website/docs/d/triton_fabric_network.html.markdown
@@ -1,0 +1,98 @@
+---
+layout: "triton"
+page_title: "Triton: triton_fabric_network"
+sidebar_current: "docs-triton-datasource-fabric-network"
+description: |-
+  The `triton_fabric_network` data source queries Triton for Fabric Network
+  information (e.g., subnet CIDR, gateway, static routes, etc.) based on the
+  name of the Fabric Network and ID of the VLAN on which the network has been
+  created.
+---
+
+# triton_fabric_network
+
+The `triton_fabric_network` data source queries Triton for [Fabric Network][4]
+information (e.g., subnet CIDR, gateway, state routes, etc.) based on the
+name of the Fabric Network and ID of the VLAN on which the network has been
+created.
+
+## Example Usages
+
+Find the subnet CIDR of a Fabric Network:
+
+```hcl
+# Declare the data source to retrieve Fabric VLAN details.
+data "triton_fabric_vlan" "private" {
+  name = "Private-VLAN-Production"
+}
+
+# Declare the data source to retrieve Fabric Network details.
+data "triton_fabric_network" "private" {
+  name     = "Private-Network-Production"
+  vland_id = "${data.triton_fabric_vlan.private.vlan_id}"
+}
+
+# Access subnet CIDR using output from the data source.
+output "private_network_cidr" {
+  value = "${data.triton_fabric_network.private.subnet}"
+}
+```
+
+## Argument Reference
+
+~> **NOTE:** You can use the [triton_fabric_vlan][1] data source to
+retrieve details about a [Fabric VLAN][2] for reference.
+
+The following arguments are supported:
+
+* `name` - (string)
+    **Required.** The name of the Fabric Network.
+
+* `vlan_id` - (integer)
+    **Required.** The unique identifier (VLAN ID) of the Fabric VLAN.
+
+## Attribute Reference
+
+* `name` - (string)
+    The name of the Fabric Network.
+
+* `public` - (boolean)
+    Whether this Fabric Network is a public or private [RFC1918][3] network.
+
+* `fabric` - (boolean)
+    Whether this network is created on a [Fabric][4]. This is always
+    **true** for a Fabric Network.
+
+* `description` - (string)
+    The description of the Fabric Network, if any.
+
+* `subnet` - (string)
+    A [CIDR][5] block used for the Fabric Network.
+
+* `provision_start_ip` - (string)
+    The first IP address on this network that may be assigned.
+
+* `provision_end_ip` - (string)
+    The last IP address on this network that may be assigned.
+
+* `gateway` - (string)
+    An IP address of the gateway on this network, if any.
+
+* `resolvers` - (list)
+    A list of IP addresses of DNS resolvers on this network.
+
+* `routes` - (map)
+    A map of static routes (using the [CIDR][5] notation) and corresponding gateways on this network, if any.
+
+* `internet_nat` - (boolean)
+    Whether the gateway on this network is also provisioned with the
+    Internet NAT zone.
+
+* `vlan_id` - (integer)
+    The unique identifier (VLAN ID) of the Fabric VLAN.
+
+[1]: /docs/providers/triton/d/triton_fabric_vlan.html
+[2]: https://docs.joyent.com/public-cloud/network/sdn#vlans
+[3]: https://tools.ietf.org/html/rfc1918
+[4]: https://docs.joyent.com/public-cloud/network/sdn
+[5]: https://tools.ietf.org/html/rfc4632

--- a/website/triton.erb
+++ b/website/triton.erb
@@ -29,6 +29,9 @@
                         <li<%= sidebar_current("docs-triton-datasource-triton-fabric-vlan") %>>
                             <a href="/docs/providers/triton/d/triton_fabric_vlan.html">triton_fabric_vlan</a>
                         </li>
+                        <li<%= sidebar_current("docs-triton-datasource-triton-fabric-network") %>>
+                            <a href="/docs/providers/triton/d/triton_fabric_network.html">triton_fabric_network</a>
+                        </li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
This commit adds new data source called `triton_fabric_network`, which allows the
end-user to find details about a particular Fabric Network based on the unique name
of the network, which is used as a filter.

Signed-off-by: Krzysztof Wilczynski <kw@linux.com>