### PR TITLE
Update Go requirement to 1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.8 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.9 (to build the provider plugin)
 -   [Dep](https://github.com/golang/dep#setup) for dependency management
 
 Building The Provider


### PR DESCRIPTION
The triton provider needs go 1.9 to compile properly. 

When I tried to build v0.4.2 using Go 1.8.7 I got the following error:
```
+ make build
==> Checking that code complies with gofmt requirements...
go install
# github.com/terraform-providers/terraform-provider-triton/vendor/github.com/hashicorp/terraform/config
vendor/github.com/hashicorp/terraform/config/testing.go:9: t.Helper undefined (type *testing.T has no field or method Helper)
make: *** [GNUmakefile:7: build] Error 2
Traceback (most recent call last):
  File "/opt/conda/bin/conda-build", line 6, in <module>
    sys.exit(conda_build.cli.main_build.main())
  File "/opt/conda/lib/python3.6/site-packages/conda_build/cli/main_build.py", line 342, in main
    execute(sys.argv[1:])
  File "/opt/conda/lib/python3.6/site-packages/conda_build/cli/main_build.py", line 333, in execute
    noverify=args.no_verify)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/api.py", line 97, in build
    need_source_download=need_source_download, config=config)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/build.py", line 1524, in build_tree
    config=config)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/build.py", line 1147, in build
    utils.check_call_env(cmd, env=env, cwd=src_dir)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/utils.py", line 628, in check_call_env
    return _func_defaulting_env_to_os_environ(subprocess.check_call, *popenargs, **kwargs)
  File "/opt/conda/lib/python3.6/site-packages/conda_build/utils.py", line 624, in _func_defaulting_env_to_os_environ
    return func(_args, **kwargs)
  File "/opt/conda/lib/python3.6/subprocess.py", line 291, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/bin/bash', '-x', '-e', '/opt/conda/conda-bld/terraform-provider-triton_1520911314787/work/terraform-provider-triton-0.4.2/conda_build.sh']' returned non-zero exit status 2.
```