### PR TITLE
resource/machine: Deprecate `locality` in favour of `affinity`

### DIFF
--- a/triton/resource_machine.go
+++ b/triton/resource_machine.go
@@ -58,36 +58,16 @@ func resourceMachine() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: resourceMachineValidateName,
 			},
-			"type": {
-				Description: "Machine type (smartmachine or virtualmachine)",
+			"package": {
+				Description: "The package for use for provisioning",
 				Type:        schema.TypeString,
-				Computed:    true,
+				Required:    true,
 			},
-			"dataset": {
-				Description: "Dataset URN with which the machine was provisioned",
+			"image": {
+				Description: "UUID of the image",
 				Type:        schema.TypeString,
-				Computed:    true,
-			},
-			"memory": {
-				Description: "Amount of memory allocated to the machine (in Mb)",
-				Type:        schema.TypeInt,
-				Computed:    true,
-			},
-			"disk": {
-				Description: "Amount of disk allocated to the machine (in Gb)",
-				Type:        schema.TypeInt,
-				Computed:    true,
-			},
-			"ips": {
-				Description: "IP addresses assigned to the machine",
-				Type:        schema.TypeList,
-				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
-			"tags": {
-				Description: "Machine tags",
-				Type:        schema.TypeMap,
-				Optional:    true,
+				Required:    true,
+				ForceNew:    true,
 			},
 			"cns": {
 				Description: "Container Name Service",
@@ -118,6 +98,7 @@ func resourceMachine() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"locality": {
+				Deprecated:  "`locality` was replaced by `affinity` in the underlying Triton API.",
 				Description: "UUID based locality hints for assisting placement behavior",
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -138,37 +119,6 @@ func resourceMachine() *schema.Resource {
 						},
 					},
 				},
-			},
-			"metadata": {
-				Description: "Machine metadata",
-				Type:        schema.TypeMap,
-				Optional:    true,
-			},
-			"created": {
-				Description: "When the machine was created",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
-			"updated": {
-				Description: "When the machine was updated",
-				Type:        schema.TypeString,
-				Computed:    true,
-			},
-			"package": {
-				Description: "The package for use for provisioning",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"image": {
-				Description: "UUID of the image",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-			},
-			"primaryip": {
-				Description: "Primary (public) IP address for the machine",
-				Type:        schema.TypeString,
-				Computed:    true,
 			},
 
 			"networks": {
@@ -241,24 +191,24 @@ func resourceMachine() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
-			"domain_names": {
-				Description: "List of domain names from Triton CNS",
-				Type:        schema.TypeList,
-				Computed:    true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
 
-			// computed resources from metadata
+			// Metadata and Tags
+			"tags": {
+				Description: "Machine tags",
+				Type:        schema.TypeMap,
+				Optional:    true,
+			},
+			"metadata": {
+				Description: "Machine metadata",
+				Type:        schema.TypeMap,
+				Optional:    true,
+			},
 			"root_authorized_keys": {
 				Description: "Authorized keys for the root user on this machine",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 			},
-
-			// resources derived from metadata
 			"user_script": {
 				Description: "User script to run on boot (every boot on SmartMachines)",
 				Type:        schema.TypeString,
@@ -282,6 +232,57 @@ func resourceMachine() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+			},
+
+			// Instance computed parameters
+			"created": {
+				Description: "When the machine was created",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"updated": {
+				Description: "When the machine was updated",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"primaryip": {
+				Description: "Primary (public) IP address for the machine",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"domain_names": {
+				Description: "List of domain names from Triton CNS",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"type": {
+				Description: "Machine type (smartmachine or virtualmachine)",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"dataset": {
+				Description: "Dataset URN with which the machine was provisioned",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"memory": {
+				Description: "Amount of memory allocated to the machine (in Mb)",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"disk": {
+				Description: "Amount of disk allocated to the machine (in Gb)",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"ips": {
+				Description: "IP addresses assigned to the machine",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"compute_node": {
 				Description: "UUID of the server on which the instance is located",

--- a/website/docs/r/triton_machine.html.markdown
+++ b/website/docs/r/triton_machine.html.markdown
@@ -128,7 +128,7 @@ The following arguments are supported:
 * `affinity` - (list of Affinity rules, Optional)
     A list of valid [Affinity Rules](https://apidocs.joyent.com/cloudapi/#affinity-rules) to apply to the machine which assist in data center placement. Using this attribute will force resource creation to be serial. NOTE: Affinity rules are best guess and assist in placing instances across a data center. They're used at creation and not referenced after.
 
-* `locality` - (map of Locality hints, Optional)
+* `(Deprecated) locality` - (map of Locality hints, Optional)
     A mapping of [Locality](https://apidocs.joyent.com/cloudapi/#CreateMachine) attributes to apply to the machine that assist in data center placement. NOTE: Locality hints are only used at the time of machine creation and not referenced after. Locality is deprecated as of
     [CloudAPI v8.3.0](https://apidocs.joyent.com/cloudapi/#830).
 


### PR DESCRIPTION
As per the change in CloudAPI, affinity is favoured over locality

Also, reordered the triton_machine schema to group similar together