### PR TITLE
resource/fabric: Default internet_nat to true

### DIFF
--- a/triton/resource_fabric.go
+++ b/triton/resource_fabric.go
@@ -16,6 +16,9 @@ func resourceFabric() *schema.Resource {
 		Read:   resourceFabricRead,
 		Delete: resourceFabricDelete,
 
+		SchemaVersion: 1,
+		MigrateState:  resourceFabricMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Description: "Network name",
@@ -79,7 +82,7 @@ func resourceFabric() *schema.Resource {
 			},
 			"internet_nat": {
 				Description: "Whether or not a NAT zone is provisioned at the Gateway IP address",
-				Computed:    true,
+				Default:     true,
 				Optional:    true,
 				ForceNew:    true,
 				Type:        schema.TypeBool,

--- a/triton/resource_fabric_migrate.go
+++ b/triton/resource_fabric_migrate.go
@@ -1,0 +1,36 @@
+package triton
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceFabricMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Fabric State v0; migrating to v1")
+		return migrateFabricStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateFabricStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before Migration: %#v", is.Attributes)
+
+	if is.Attributes["internet_nat"] != "true" {
+		is.Attributes["internet_nat"] = "false"
+	}
+
+	log.Printf("[DEBUG] Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/triton/resource_fabric_migrate_test.go
+++ b/triton/resource_fabric_migrate_test.go
@@ -1,0 +1,49 @@
+package triton
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestFabricMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1_not_set_should_be_false": {
+			StateVersion: 0,
+			ID:           "tf-testing-file",
+			Attributes:   map[string]string{},
+			Expected:     "false",
+		},
+		"v0_1_set_to_true_do_nothing": {
+			StateVersion: 0,
+			ID:           "tf-testing-file",
+			Attributes: map[string]string{
+				"internet_nat": "true",
+			},
+			Expected: "true",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceFabricMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.Attributes["internet_nat"] != tc.Expected {
+			t.Fatalf("Bad internet_nat migration: %s\n\n expected: %s", is.Attributes["internet_nat"], tc.Expected)
+		}
+	}
+}

--- a/website/docs/r/triton_fabric.html.markdown
+++ b/website/docs/r/triton_fabric.html.markdown
@@ -58,8 +58,8 @@ The following arguments are supported:
     Map of CIDR block to Gateway IP address.
 
 * `internet_nat` - (Bool, Optional, Change forces new resource)
-    If a NAT zone is provisioned at Gateway IP address. Default is `false`. This differs from [CloudAPI](https://apidocs.joyent.com/cloudapi/#CreateFabricNetwork) which implicitly creates a NAT instance by default.
-    NOTE: There is a known issue in Triton that prevents deletion of fabric networks when `internet_nat` is enabled.
+    If a NAT zone is provisioned at Gateway IP address. Default is `true`.
+
 
 * `vlan_id` - (Int, Required, Change forces new resource)
     VLAN id the network is on. Number between 0-4095 indicating VLAN ID.


### PR DESCRIPTION
Fixes: #100

As the underlying issue preventing this from working in CloudAPI has
been fixed, we are now defaulting to the same as CloudAPI

We have included a migration here to preserve backwards compatibility:

```
=== RUN   TestFabricMigrateState
2018/03/28 00:54:53 [INFO] Found Fabric State v0; migrating to v1
2018/03/28 00:54:53 [DEBUG] Attributes before Migration: map[string]string{"internet_nat":"true"}
2018/03/28 00:54:53 [DEBUG] Attributes after State Migration: map[string]string{"internet_nat":"true"}
2018/03/28 00:54:53 [INFO] Found Fabric State v0; migrating to v1
2018/03/28 00:54:53 [DEBUG] Attributes before Migration: map[string]string{}
2018/03/28 00:54:53 [DEBUG] Attributes after State Migration: map[string]string{"internet_nat":"false"}
--- PASS: TestFabricMigrateState (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-triton/triton    0.020s
```

The existing Acceptance test also passes:

```
terraform-provider-triton [default-internet_nat_to_true●●] % acctests triton TestAccTritonFabric_
=== RUN   TestAccTritonFabric_basic
--- PASS: TestAccTritonFabric_basic (30.07s)
PASS
ok  	github.com/terraform-providers/terraform-provider-triton/triton	30.096s
```